### PR TITLE
Publishing to Single-file in .Net Core

### DIFF
--- a/accepted/single-file/design.md
+++ b/accepted/single-file/design.md
@@ -118,7 +118,7 @@ dotnet publish --single-file
 By default, `PublishSingleFile` bundles all files in the publish directory into the single executable. This behavior can be altered by using the following content meta-data:
 
 ```xml
-<IncludeInSingleFilePublish>{Always, PreserveNewest, Never}</IncludeInSingleFilePublish>
+<IncludeInSingleFile>{Always, PreserveNewest, Never}</IncludeInSingleFile>
 ```
 
 For example, to place some files in the publish directory but not bundle them in the single-file:
@@ -127,7 +127,7 @@ For example, to place some files in the publish directory but not bundle them in
 <ItemGroup>
     <Content Update="*.xml">
       <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
-      <IncludeInSingleFilePublish>PreserveNewest</CopyToPublishDirectory>
+      <IncludeInSingleFile>PreserveNewest</IncludeInSingleFile>
     </Content>
   </ItemGroup>
 ```

--- a/accepted/single-file/design.md
+++ b/accepted/single-file/design.md
@@ -78,7 +78,7 @@ To any host (native binary) specified, the bundler tool will add:
 
 ##### Implementation
 
-The bundler should ideally be located close to the dotnet host, since their implementation is closely related. Therefore, the bundler will be implemented in the `core-setup` repo. The `corehost` code is expected to move to the CoreCLR repo, at which point, the bundler should move with it. The bundler will be implemented in managed code.
+The bundler should ideally be located close to the core-host, since their implementation is closely related. Therefore, the bundler will be implemented in the `core-setup` repo. The bundler will be implemented in managed code.
 
 ##### Command Line Interface
 
@@ -237,7 +237,18 @@ The semantics of assembly location should be tuned further based on user feedbac
 * A subset of CoreCLR Tests
 * Tests to ensure that MSIL files with embedded PDBs are handled correctly
 * End-to-End testing on real world apps such as Roslyn, MusicStore
-* *Measurements*: Publish size and run-time (first run, subsequent runs) for HelloWorld, Roslyn and MusicStore.
+
+#### Measurements
+
+Measure publish size and run-time (first run, subsequent runs) for HelloWorld (framework-dependent and self-contained), Roslyn and MusicStore.
+
+#### Telemetry
+
+Collect telemetry for single-file published apps with respect to parameters such as:
+
+* Framework-dependent vs self-contained apps.
+* Whether the apps are Pure managed apps, ready-to run compiled apps, or have native dependencies.
+* Embedding of additional/data files, and use of file access API.
 
 ## Further Work
 
@@ -259,8 +270,6 @@ The above design should be extended to seamlessly support single-file publish fo
 - For host/runtime support, the options are:
   - Implement plugins using existing infrastructure. For example: Take control of assembly/native binary loads via existing `AssemblyLoadContext` callbacks and events. Extract the files embedded within the single-file plugin using the `GetFileStream()` API and load them on demand.
   - Have new API to load a single-file plugin, for example: `AssemblyLoadContext.LoadWithEmbeddedDependencies()`.
-
-
 
 #### VS Integration
 

--- a/accepted/single-file/design.md
+++ b/accepted/single-file/design.md
@@ -78,21 +78,9 @@ To any host (native binary) specified, the bundler tool will add:
 
 ##### Implementation
 
-The bundler should ideally be located close to the core-host, since their implementation is closely related. Therefore, the bundler will be implemented in the `core-setup` repo. The bundler will be implemented in managed code.
+The bundler should ideally be located close to the core-host, since their implementation is closely related. Therefore, the bundler will be implemented in the `core-setup` repo. 
 
-##### Command Line Interface
-
-The bundler will be a standalone tool with the following command line:
-
-```bash
-bundle -a <App>      The name of the managed app
-       -h <Host>     The path to the native host
-       -c <contents> The path to a directory containing the files to bundle
-       [-o <output>] The path to output bundle
-       [-v]          Generate verbose output
-```
-
-Most users are only expected to interact with the bundler via the build system.
+The bundler will be implemented in managed code as a standalone tool. Application developers are expected to interact with the bundler only through the build system. The `dotnet` SDK will implement msbuild-tasks that use this tool to publish single-file apps.  
 
 ##### Build System Interface
 

--- a/accepted/single-file/design.md
+++ b/accepted/single-file/design.md
@@ -310,5 +310,6 @@ Most applications are expected to work without any changes. However, apps with a
 * [Mono/MkBundle](https://github.com/mono/mono/blob/master/mcs/tools/mkbundle) 
 * [Fody.Costura](https://github.com/Fody/Costura)
 * [Warp](https://github.com/dgiagio/warp)
+* [dotnet-warp](https://github.com/Hubert-Rybak/dotnet-warp)
 * [BoxedApp](https://docs.boxedapp.com/index.html)
 

--- a/accepted/single-file/design.md
+++ b/accepted/single-file/design.md
@@ -166,26 +166,23 @@ Where
 the TPA with single-exe publish will be (assuming `?` is the bundle marker):
 `?/il.dll`; `/tmp/.net/e53xf3/r2r.dll`; `/usr/local/nuget/dep.dll`
 
-## Testing
+### New API
 
-* Unit Tests to achieve good coverage on apps using managed, ready-to-run, native code 
-* Tests to verify that framework-dependent and self-contained apps can be published as single file.
-* Tests for ensure that every app model template supported by .NET Core (console, wpf, winforms, web, etc.) can be published as a single file.
-* A subset of CoreCLR Tests
-* End-to-End testing on real world apps such as Roslyn, MusicStore
-* *Measurements*: Publish size and run-time (first run, subsequent runs) for HelloWorld, Roslyn and MusicStore.
+We propose adding the following API to the .net core framework to facilitate operation of apps published as single-files 
 
-## Further Work
+#### Single-file? 
 
-#### Bundler Optimizations
+Check whether an app is running from a single-file bundle:
 
-Since all the files of an app published as a single-file live together, we can perform the following optimizations
-
-- R2R compile the app and all of its dependent assemblies in a single version-bubble
-
-  Single-file apps compiled cross-platform may have this optimization disabled until the ready-to-run compiler  (`crossgen`) supports cross-compilation. 
-
-- Investigate whether collectively signing the files in an assembly saves space for certificates.
+```cs
+namespace System.Runtime.Loader
+{
+    public partial class Bundle
+    {
+        public static bool IsBundle(Assembly assembly);
+    }
+}
+```
 
 #### APIs to access Bundled files
 
@@ -209,6 +206,29 @@ namespace System.Runtime.Loader
 ```
 
 We can also provide an abstraction that abstracts away the physical location of a file (bundle or disk). For example, add a variant of  `GetFileStream` API that looks for a file in the bundle, and if not found, falls back to disk-lookup.
+
+## Testing
+
+* Unit Tests to achieve good coverage on apps using managed, ready-to-run, native code 
+* Tests for the newly added API 
+* Tests to verify that framework-dependent and self-contained apps can be published as single file.
+* Tests for ensure that every app model template supported by .NET Core (console, wpf, winforms, web, etc.) can be published as a single file.
+* A subset of CoreCLR Tests
+* Tests to ensure that MSIL files with embedded PDBs are handled correctly
+* End-to-End testing on real world apps such as Roslyn, MusicStore
+* *Measurements*: Publish size and run-time (first run, subsequent runs) for HelloWorld, Roslyn and MusicStore.
+
+## Further Work
+
+#### Bundler Optimizations
+
+Since all the files of an app published as a single-file live together, we can perform the following optimizations
+
+- R2R compile the app and all of its dependent assemblies in a single version-bubble
+
+  Single-file apps compiled cross-platform may have this optimization disabled until the ready-to-run compiler  (`crossgen`) supports cross-compilation. 
+
+- Investigate whether collectively signing the files in an assembly saves space for certificates.
 
 #### Single-file Plugins
 

--- a/accepted/single-file/design.md
+++ b/accepted/single-file/design.md
@@ -266,6 +266,7 @@ To summarize, here's the overall experience for creating a HelloWorld single-fil
 
   * The bundled app and configuration files are processed directly from the bundle.
   * Remaining 216 files will be extracted to disk at startup. 
+  * If reuse of extracted files is enabled, subsequent runs of the app may skip the extraction step.
 
 
 Most applications are expected to work without any changes. However, apps with a strong expectation about absolute location of dependent files may need to be made aware of bundling and extraction aspects of single-file publishing. No difference is expected with respect to debugging and analysis of apps.

--- a/accepted/single-file/design.md
+++ b/accepted/single-file/design.md
@@ -1,0 +1,279 @@
+# Single-file Publish
+
+Design for publishing apps as a single-file in .Net Core 3.0
+
+## Introduction
+
+The goal of this effort is enable .Net-Core apps to be published and distributed as a single executable.
+
+There are several strategies to implement this feature -- ranging from bundling the published files into zip file (ex: [Warp](https://github.com/dgiagio/warp)), to native compiling and linking all the binaries together (ex: [CoreRT](https://github.com/dotnet/corert)). These options, along with their cost/benefit analysis is explored in this [staging document](staging.md).
+
+#### Goals
+
+In .Net Core 3.0, we plan to implement a solution that 
+
+* Is widely compatible: Apps containing MSIL assemblies, ready-to-run assemblies, native binaries, configuration files, etc. can be packaged into one executable.
+* Can run framework dependent pure managed apps directly from bundle:
+  * Executes IL assemblies, and processes configuration files directly from the bundled executable.
+  * Extracts ready-to-run and native binaries to disk before loading them.
+* Usable with debuggers and tools:  The single-file should be debuggable using the generated symbol file. It should also be usable with profilers and tools similar to a non-bundled app.
+
+This feature-set is described as Stage 2 in the [staging document](staging.md), and can be improvised in further releases.
+
+#### Non Goals
+
+* Optimizing for development: The single-file publishing is typically not a part of the development cycle. It is typically used in release builds as a packaging step. Therefore, the single-file feature will be designed with focus on consumption rather than production.
+* Merging IL: Tools like [ILMerge](https://github.com/dotnet/ILMerge) combines the IL from many assemblies into one, but lose assembly identity in the process. This is not a goal for single-file feature.
+
+#### Existing tools
+
+Single-file packaging for .Net Core apps is currently supported by third-party tools such as [Warp](https://github.com/dgiagio/warp) and [Costura](https://github.com/Fody/Costura). We now consider the pros and cons of implementing this feature within .Net Core.
+
+##### Advantages
+
+* A standardized experience available for all apps
+* Integration with dotnet CLI
+* A more transparent experience: for example, external tools may utilize public APIs such `AssemblyLoadContext.Resolving` or `AssemblyLoadContext.ResolvingUnmanagedDll` events to load files from a bundle. However, this may conflict with the app's own use of these APIs, which requires a cooperative resolution. Such a situation is avoided by providing inbuilt support for single-file apps.
+
+##### Limitations
+
+* Inbox implementation of the feature adds complexity for customers with respect to the list of deployment options to choose from.
+* Independent tools can evolve faster on their own schedule.
+* Independent tools can provide richer set of features catering to match a specific set of customers.
+
+We believe that the advantages outweigh the disadvantages in with respect to implementing this feature inbox.
+
+## Design
+
+There are two main aspects to publishing apps as a self-extracting single file:
+
+- The Bundler: A tool that embeds the managed app, its dependencies, and the runtime into a single host executable.
+- The host: The "single-file" which facilitates the extraction and/or loading of embedded components.
+
+### The Bundler
+
+#### Bundling Tool
+
+The bundler tool must be:
+
+* Able to embed any file required to run a .Net Core app -- managed assemblies, native binaries, configuration files, data files, etc.
+* Able to generate cross-platform bundles (ex: publish a single-file for Linux target from Windows)
+* Deterministic (generate the exact same single-file on multiple runs)
+
+With the above requirements in mind, we plan to implement a tool similar to [MkBundle](https://github.com/mono/mono/blob/master/mcs/tools/mkbundle) that simply appends the bundled dependencies as a binary blob at the end of a host binary.
+
+To any host (native binary) specified, the bundler tool will add:
+
+* A footer that contains:
+  * A flag to identify that this is actually a bundle.
+  * A version identifier.
+  * Offset of the bundle manifest
+* A manifest that identifies (via offset and size)
+  * The configuration files `app.deps.json` `app.runtimeconfig.json`
+  * The embedded app to load
+  * The set of MSIL images
+  * The set of ready-to-run images
+  * All other files
+* The actual files to be bundled.
+
+##### Implementation
+
+The bundler should ideally be located close to the dotnet host, since their implementation is closely related. Therefore, the bundler will be implemented in the `core-setup` repo. The `corehost` code is expected to move to the CoreCLR repo, at which point, the bundler should move with it. The bundler will be implemented in managed code.
+
+##### Command Line Interface
+
+The bundler will be a standalone tool with the following command line:
+
+```bash
+bundle -a <App>      The name of the managed app
+       -h <Host>     The path to the native host
+       -c <contents> The path to a directory containing the files to bundle
+       [-o <output>] The path to output bundle
+       [-v]          Generate verbose output
+```
+
+Most users are only expected to interact with the bundler via the build system.
+
+##### Build System Interface
+
+Publishing to a single file can be triggered by adding the following property to an application's project file:
+
+```xml
+<PropertyGroup>
+    <PublishSingleFile>true</PublishSingleFile>
+</PropertyGroup>    
+```
+
+* The `PublishSingleFile` property applies to both framework dependent and self-contained publish operations.
+* Setting the `PublishSingleFile`property causes the managed app, dependencies, configurations, etc. (basically the contents of the publish directory when `dotnet publish` is run without setting the property) to be embedded within the native `apphost`. The publish directory will only contain the single bundled executable (and the symbol file).
+
+Optionally, we can add the following switch to the CLI, as a shortcut to setting the `PublishSingleFile` property.
+
+```bash
+dotnet publish --single-file
+```
+
+#### Interaction with other tools
+
+Once the single-file-publish tooling is added to the publish pipeline, other static binary transformation tools may need to adapt its presence. For example:
+
+* The MSBuild logic in `dotnet SDK` should be crafted such that [IlLinker](https://github.com/dotnet/core/blob/master/samples/linker-instructions.md), [crossgen](https://github.com/dotnet/coreclr/blob/master/Documentation/building/crossgen.md), and the single-file bundler run in that order in the build/publish sequence. 
+* External tools like [Fody](https://github.com/Fody/Fody) that use  `AfterBuild`/`AfterPublish` targets may need to adapt to expect the significantly different output generated by publishing to a single file. The goal in this case is to provide sufficient documentation and guidance.
+
+### The Host
+
+On Startup, the AppHost checks if it has embedded files. If so, it 
+
+* Processes configuration files such as `app.deps.json` , `app.runtimeconfig.json` from the embedded files, instead of looking for them on the disk next to the app.
+* Sets up the data-structures to locate pure managed assemblies within the bundle so that they can be loaded on-demand.
+* Extracts the other files (native libraries, ready-to-run compiled assemblies, and other data files to an *install-location*). Extraction of files is discussed in detail in this  [document](extract.md). 
+* Communicates the information about bundled and extracted files to the runtime, as explained in the section on dependency resolution.
+
+#### Dependency Resolution
+
+An app may choose to only embed some files (ex: due to licensing restrictions) and expect to pickup other dependencies from application-launch directory, nuget packages, etc. In order to resolve assemblies and native libraries, the embedded resources are probed first, followed by other probing paths. 
+
+The communication between the host and the runtime will continue to be through properties such as `TRUSTED_PLATFORM_ASSEMBLIES`, `NATIVE_DLL_SEARCH_DIRECTORIES`, etc.  These properties will be populated with entries from the bundled files (using a special marker) and the extracted files.
+
+For example, if the TPA without single-exe publish is:
+`~/app/il.dll`; `~/app/r2r.dll`; `/usr/local/nuget/dep.dll`
+
+Where
+
+* `il.dll` is a pure managed assembly that is loaded directly from the bundle
+* `r2r.dll` is a ready-to-run assembly that is bundled and extract out to disk
+* `dep.dll` is an assembly that is not bundled with the app,
+
+the TPA with single-exe publish will be (assuming `?` is the bundle marker):
+`?/il.dll`; `/tmp/.net/e53xf3/r2r.dll`; `/usr/local/nuget/dep.dll`
+
+## Testing
+
+* Unit Tests to achieve good coverage on apps using managed, ready-to-run, native code 
+* Tests to verify that framework-dependent and self-contained apps can be published as single file.
+* Tests for ensure that every app model template supported by .NET Core (console, wpf, winforms, web, etc.) can be published as a single file.
+* A subset of CoreCLR Tests
+* End-to-End testing on real world apps such as Roslyn, MusicStore
+* *Measurements*: Publish size and run-time (first run, subsequent runs) for HelloWorld, Roslyn and MusicStore.
+
+## Further Work
+
+#### Bundler Optimizations
+
+Since all the files of an app published as a single-file live together, we can perform the following optimizations
+
+- R2R compile the app and all of its dependent assemblies in a single version-bubble
+- Investigate whether collectively signing the files in an assembly saves space for certificates.
+
+#### APIs to access Bundled files
+
+The binaries that are published in the project are expected to be handled transparently by the host. However, explicit access to the embedded files is useful in situations such as:
+
+- Reading additional files packaged into the app (ex: data files).
+- Open an assembly for reflection/inspection
+- Load plugins built as single-file class-libs using existing Loader APIs.
+
+In facilitate this usage, we can add an API similar to [GetManifestResourceStream](https://docs.microsoft.com/en-us/dotnet/api/system.reflection.assembly.getmanifestresourcestream?view=netframework-4.7.2#System_Reflection_Assembly_GetManifestResourceStream_System_String_) to obtain a stream corresponding to an embedded file. 
+
+```C#
+// Open a file embedded in the bundle built for the specified assembly 
+namespace System.Runtime.Loader
+{
+    public partial class Bundle
+    {
+        public static System.IO.Stream GetFileStream(Assembly assembly, string name);
+    }
+}
+```
+
+We can also provide an abstraction that abstracts away the physical location of a file (bundle or disk). For example, add a variant of  `GetFileStream` API that looks for a file in the bundle, and if not found, falls back to disk-lookup.
+
+#### Single-file Plugins
+
+The above design should be extended to seamlessly support single-file publish for plugins.
+
+- The bundler tool will mostly work as-is, regardless of whether we publish an application or class-lib. The binary blob with dependencies can be appended to both native and managed binaries.
+- For host/runtime support, the options are:
+  - Implement plugins using existing infrastructure. For example: Take control of assembly/native binary loads via existing `AssemblyLoadContext` callbacks and events. Extract the files embedded within the single-file plugin using the `GetFileStream()` API and load them on demand.
+  - Have new API to load a single-file plugin, for example: `AssemblyLoadContext.LoadWithEmbeddedDependencies()`.
+
+#### Project File Options
+
+By default, `PublishSingleFile` bundles all files in the publish directory into the single executable. This behavior can be altered via the following configurations in the application's project file.
+
+* Exclude certain files in the publish directory from being bundled (ex: because of licensing issues or for testing purposes).
+
+```xml
+<ItemGroup>
+    <SingleFileExclude Include="List of patterns to exclude"/>
+</ItemGroup>
+```
+
+- Add additional files to the bundle from other locations (ex: add data files to the app). The developer will be responsible for handling these additional files.
+
+```xml
+<ItemGroup>
+    <SingleFileAdd Include="List of file paths"/>
+</ItemGroup>
+```
+
+An app may choose to have all of its dependencies extracted to disk at runtime (instead of loading certain files directly from the bundle) by setting the following property.
+
+```xml
+<PropertyGroup>
+    <SingleFileExtractAll>true</SingleFileExtractAll>
+</PropertyGroup>
+```
+
+#### VS Integration
+
+Developers should be able to use the feature easily from Visual Studio. The feature will start with text based support -- by explicitly setting the `PublishSingleFile` property in the project file. In future, we may provide a single-file publish-profile, or other UI triggers.
+
+## User Experience
+
+To summarize, here's the overall experience for creating a HelloWorld single-file app 
+
+*  Create a new HelloWorld app: `HelloWorld$ dotnet new console`
+
+#### Framework Dependent HelloWorld
+
+* Normal publish: `dotnet publish` 
+
+  * Publish directory contains the host `HelloWorld.exe` ,  the app `HelloWorld.dll`, configuration files `HelloWorld.deps.json`, `HelloWorld.runtimeconfig.json`, and the symbol-file `HelloWorld.pdb`.
+
+* Single-file publish: `dotnet publish /p:PublishSingleFile=true`
+
+  * Publish directory contains: `HelloWorld.exe` `HelloWorld.pdb`
+
+  * `HelloWorld.dll`, `HelloWorld.deps.json`, and `HelloWorld.runtimeconfig.json` are embedded within `HelloWorld.exe`.
+
+* Run: `HelloWorld.exe`
+
+  * The app runs completely from the single-file, without the need for intermediate extraction to file.
+
+#### Self-Contained HelloWorld
+
+- Normal publish: `dotnet publish -r win10-x64 --self-contained`
+
+  * Publish directory contains 221 files including the host, the app, configuration files, the symbol-file and the runtime.
+
+- Single-file publish: `dotnet publish -r win10-x64 --self-contained /p:PublishSingleFile=true`
+
+  - Publish directory contains: `HelloWorld.exe` `HelloWorld.pdb`
+  - The remaining 219 files are embedded within the host `HelloWorld.exe`.
+
+- Run: `HelloWorld.exe`
+
+  * The bundled app and configuration files are processed directly from the bundle.
+  * Remaining 216 files will be extracted to disk at startup. 
+
+
+Most applications are expected to work without any changes. However, apps with a strong expectation about absolute location of dependent files may need to be made aware of bundling and extraction aspects of single-file publishing. No difference is expected with respect to debugging and analysis of apps.
+
+## Related Work
+
+* [Mono/MkBundle](https://github.com/mono/mono/blob/master/mcs/tools/mkbundle) 
+* [Fody.Costura](https://github.com/Fody/Costura)
+* [Warp](https://github.com/dgiagio/warp)
+* [BoxedApp](https://docs.boxedapp.com/index.html)
+

--- a/accepted/single-file/design.md
+++ b/accepted/single-file/design.md
@@ -105,7 +105,8 @@ Publishing to a single file can be triggered by adding the following property to
 ```
 
 * The `PublishSingleFile` property applies to both framework dependent and self-contained publish operations.
-* Setting the `PublishSingleFile`property causes the managed app, dependencies, configurations, etc. (basically the contents of the publish directory when `dotnet publish` is run without setting the property) to be embedded within the native `apphost`. The publish directory will only contain the single bundled executable (and the symbol file).
+* The `PublishSingleFile` property applies to platform-specific builds with respect to a given runtime-identifier. The output of the build is a native binary for the specified platform.
+* Setting the `PublishSingleFile`property causes the managed app, managed dependencies, platform-specific native dependencies, configurations, etc. (basically the contents of the publish directory when `dotnet publish` is run without setting the property) to be embedded within the native `apphost`. The publish directory will only contain the single bundled executable (and the PDB file).
 
 Optionally, we can add the following switch to the CLI, as a shortcut to setting the `PublishSingleFile` property.
 
@@ -239,7 +240,7 @@ To summarize, here's the overall experience for creating a HelloWorld single-fil
 
 * Normal publish: `dotnet publish` 
 
-  * Publish directory contains the host `HelloWorld.exe` ,  the app `HelloWorld.dll`, configuration files `HelloWorld.deps.json`, `HelloWorld.runtimeconfig.json`, and the symbol-file `HelloWorld.pdb`.
+  * Publish directory contains the host `HelloWorld.exe` ,  the app `HelloWorld.dll`, configuration files `HelloWorld.deps.json`, `HelloWorld.runtimeconfig.json`, and the PDB-file `HelloWorld.pdb`.
 
 * Single-file publish: `dotnet publish /p:PublishSingleFile=true`
 
@@ -255,7 +256,7 @@ To summarize, here's the overall experience for creating a HelloWorld single-fil
 
 - Normal publish: `dotnet publish -r win10-x64 --self-contained`
 
-  * Publish directory contains 221 files including the host, the app, configuration files, the symbol-file and the runtime.
+  * Publish directory contains 221 files including the host, the app, configuration files, the PDB-file and the runtime.
 
 - Single-file publish: `dotnet publish -r win10-x64 --self-contained /p:PublishSingleFile=true`
 

--- a/accepted/single-file/extract.md
+++ b/accepted/single-file/extract.md
@@ -92,8 +92,24 @@ The cleanup of extracted files in the install-location will be manual in this ve
 - Unsuitable for customer scenarios that cannot tolerate persistent disk state after the app terminates.
 - Cleanup is manual.
 
-## Proposed Solution
+## Extraction Configurations
 
 The above implementation options suit different customer scenarios. So, instead of picking an extraction policy, we can implement both strategies, and let app-developers choose a strategy as part of the app's configuration.
+
+```xml
+<PropertyGroup>
+    <ExtractionStrategy>Temp-startup / Temp-Lazy / Persistent</SingleFileExtractAll>
+</PropertyGroup>
+```
+
+An app may choose to have all of its dependencies extracted to disk at runtime (instead of loading certain files directly from the bundle) by setting the following property.
+
+```xml
+<PropertyGroup>
+    <SingleFileExtractAll>true</SingleFileExtractAll>
+</PropertyGroup>
+```
+
+## Proposed Solution
 
 For .Net Core 3.0, we propose that we start with the simple implementation that extracts necessary files to temporary locations on every run at startup. Based on customer feedback, we can implement other options discussed above.

--- a/accepted/single-file/extract.md
+++ b/accepted/single-file/extract.md
@@ -1,0 +1,81 @@
+# Extracting Bundled Files to Disk
+
+When running the single-file, the host will need to extract some bundled files resources out to the disk before loading them. This is particularly true for native DLLs because of operating system API restrictions -- for example, Windows doesn't support a `LoadLibrary()` API that reads in from a stream. 
+
+We now explore the options with respect to the location and life-time of the extracted files.
+
+## Time of Extraction
+
+* **Startup**: The host spills the necessary files at startup, and communicates the location to the runtime.
+* **Lazy:** The runtime provides callbacks to extract a bundled file to disk when it is actually necessary to be loaded. 
+
+Extraction at startup is easier to implement, as the runtime needs no knowledge of the extraction. 
+
+Lazy extraction saves startup cost, particularly if many ready-to-run images are bundled. The lazy extraction feature is likely useful only when files are extracted on every run.
+
+Mono extracts native libraries at startup. Costura extracts and explicitly loads the native-libraries at startup.
+
+## Temporary Extraction
+
+The first option is to extract out the necessary files to a temporary location, and clean them out on exit. The requirements for this path are:
+
+* Extract to a location within the temp-directory, so that if some files are not removed (ex: because an app crashed before cleanup), they are removed when the temp-directory is purged.
+* Be short, to reduce the risk of running over path length limit.
+* Be randomized, in order to support concurrent launches of the same app.
+
+The proposed extraction path is `%TEMP\.net\<random-code>` / `$TMPDIR/.net/<random-code>` . 
+
+#### Pros
+
+* Simpler implementation: fewer complexities with respect to app-updates and concurrency.
+* User need not worry about explicit cleanup.
+* Some customers don't prefer a click-and-run model, rather than an app-install model. This option better suits them.
+
+#### Cons
+
+* Higher startup cost, because of extraction on every run -- especially for self-contained apps.
+
+Mono and Costura extract native dependencies to temporary files on every run.
+
+## Persistent Extraction
+
+The requirements for persistent extraction are:
+
+* Reuse: Extract on first-run, reuse on subsequent runs.
+* Fault-tolerance: Recover from failure after partial extraction on first run.
+* Concurrency: Handle concurrent launches on first start.
+* Upgrade: Each version of the app extracts to a unique location, supporting side-by-side use of multiple versions.
+* Uninstall: Users can identify and delete extracted files when the app is no longer needed.
+* Access control: Processes running with elevated access can extract to admin-only-writable locations.
+
+At first startup, the host takes a disk lock (in order to handle concurrent launches), extracts files to an *install-location*, verifies them, and writes and *end-marker* before releasing the lock. If the host fails to extract all the resources at startup, it will attempt to clean up all contents of the install-location before termination. 
+
+Subsequent runs reuse the extracted files after confirming their successful extraction. However, if the contents of install-location are corrupted post-extraction, they will need to be explicitly cleaned.
+
+By default, the host extracts dependencies to `BASE_PATH/APP_NAME/ID/PERM/`
+
+- `BASE_PATH` is  `%HOMEPATH%\.dotnet\AppDependencies ` /  `$HOME/.dotnet/AppDependencies`
+- `APP_NAME` is simple the name of the app (the host executable containing embedded data).
+- `ID` is a hash-code based on the host binary to distinguish app version and architecture specifications.
+- `PERM` is `user` for normal runs, and `admin` for elevated runs with appropriate write-permissions.
+
+A different extraction location may be specified via a `runtimeconfig` option.
+
+The cleanup of extracted files in the install-location will be manual in this version. We can consider adding `dotnet CLI` commands for cleanup in future. However, future versions are expected to spill fewer artifacts to disk, making the cleanup commands a lower priority feature.
+
+#### Pros
+
+- Saves startup cost, particularly for self-contained apps, or apps containing several native binary dependencies.
+- No need for implementing lazy-extraction.
+
+#### Cons
+
+- Complex implementation.
+- Unsuitable for customer scenarios that cannot tolerate persistent disk state after the app terminates.
+- Cleanup is manual.
+
+## Proposed Solution
+
+The above implementation options suit different customer scenarios. So, instead of picking an extraction policy, we can implement both strategies, and let app-developers choose a strategy as part of the app's configuration.
+
+For .Net Core, we propose that we start with the simple implementation that extracts necessary files to temporary locations on every run at startup. Based on customer feedback, we can implement other options discussed above.

--- a/accepted/single-file/extract.md
+++ b/accepted/single-file/extract.md
@@ -29,7 +29,7 @@ The proposed extraction path is `%TEMP\.net\<random-code>` / `$TMPDIR/.net/<rand
 
 * Simpler implementation: fewer complexities with respect to app-updates and concurrency.
 * User need not worry about explicit cleanup.
-* Some customers don't prefer a click-and-run model, rather than an app-install model. This option better suits them.
+* Suits customers who prefer click-and-run model for their apps, rather than app-install model. 
 
 #### Cons
 

--- a/accepted/single-file/extract.md
+++ b/accepted/single-file/extract.md
@@ -48,18 +48,36 @@ The requirements for persistent extraction are:
 * Uninstall: Users can identify and delete extracted files when the app is no longer needed.
 * Access control: Processes running with elevated access can extract to admin-only-writable locations.
 
-At first startup, the host takes a disk lock (in order to handle concurrent launches), extracts files to an *install-location*, verifies them, and writes and *end-marker* before releasing the lock. If the host fails to extract all the resources at startup, it will attempt to clean up all contents of the install-location before termination. 
+At first startup, the host 
+
+* Takes a disk lock (in order to handle concurrent launches).
+* Extracts appropriate files to an *install-location* on disk, and verifies them.
+* If all files are extracted successfully, host writes an *end-marker*. The end-marker will include name and version information for the app's main assembly in plain text, in order to help users in associating install-locations with app versions.
+* If there are failures, host attempts to clean up all contents of the *install-location*
+* Releases the disk lock. 
 
 Subsequent runs reuse the extracted files after confirming their successful extraction. However, if the contents of install-location are corrupted post-extraction, they will need to be explicitly cleaned.
 
+#### Install Location
+
 By default, the host extracts dependencies to `BASE_PATH/APP_NAME/ID/PERM/`
 
-- `BASE_PATH` is  `%HOMEPATH%\.dotnet\AppDependencies ` /  `$HOME/.dotnet/AppDependencies`
+- `BASE_PATH` is  `%HOMEPATH%\.dotnet\Apps ` /  `$HOME/.dotnet/Apps`
 - `APP_NAME` is simple the name of the app (the host executable containing embedded data).
 - `ID` is a hash-code based on the host binary to distinguish app version and architecture specifications.
 - `PERM` is `user` for normal runs, and `admin` for elevated runs with appropriate write-permissions.
 
-A different extraction location may be specified via a `runtimeconfig` option.
+A different extraction location may be specified via the runtime configuration settings:
+
+```json
+{
+    "runtimeoptions": {
+        "bundledFileExtractionLocation": "<path>"
+    }
+}
+```
+
+#### Cleanup
 
 The cleanup of extracted files in the install-location will be manual in this version. We can consider adding `dotnet CLI` commands for cleanup in future. However, future versions are expected to spill fewer artifacts to disk, making the cleanup commands a lower priority feature.
 

--- a/accepted/single-file/extract.md
+++ b/accepted/single-file/extract.md
@@ -78,4 +78,4 @@ The cleanup of extracted files in the install-location will be manual in this ve
 
 The above implementation options suit different customer scenarios. So, instead of picking an extraction policy, we can implement both strategies, and let app-developers choose a strategy as part of the app's configuration.
 
-For .Net Core, we propose that we start with the simple implementation that extracts necessary files to temporary locations on every run at startup. Based on customer feedback, we can implement other options discussed above.
+For .Net Core 3.0, we propose that we start with the simple implementation that extracts necessary files to temporary locations on every run at startup. Based on customer feedback, we can implement other options discussed above.

--- a/accepted/single-file/staging.md
+++ b/accepted/single-file/staging.md
@@ -27,7 +27,7 @@ This stage implements:
 
 The mechanism will support:
 
-* Reuse: Extract on first-run, reuse on subsequent runs.
+* Reuse: Extract on first-run, reuse on subsequent runs (if apps choose to do so).
 * Upgrade: Each version of the app extracts to a unique location, supporting side-by-side use of multiple versions.
 * Uninstall: Users can identify and delete extracted files when the app is no longer needed.
 * Access control: Processes running with elevated access can extract to admin-only-writable locations.

--- a/accepted/single-file/staging.md
+++ b/accepted/single-file/staging.md
@@ -1,0 +1,139 @@
+# Single-file Staging 
+
+Publishing apps as a single file is a popular feature-request in .Net Core. Ideally, we want a single-file solution that:
+
+* Is compatible with all .Net Core applications
+* Bundles MSIL, R2R, native code and custom (data) files
+* Doesn't require installation or cleanup steps
+* Runs directly from the bundle, without extracting components to disk
+* Reduces publish-size
+* Improves startup cost
+* Works cohesively with debuggers, profilers, Watson dump etc. 
+
+This document explores a few options to realize the single-file publish feature, with different feature-set vs development cost trade-offs. The document can also be considered a development staging plan, where each stage spills fewer items onto temporary files, while paying an incremental development cost.
+
+## 1. Self-Extractor
+
+The first stage is to develop a pack and extract tool.
+While this stage is technically simplistic, the interface and tooling will match the final solution, giving partner teams and potential customers a chance to prepare for adopting the technology.
+
+### 1.1 Description
+
+This stage implements:
+
+* A  packaging tool (bundler) that embeds the application and all of its dependencies (essentially the contents of the publish directory) into a host executable. 
+	* This version will not support compression of the bundled assemblies.
+* When the executable runs, it will extract all of those files into a temporary directory, and then run as though the app was published to that temporary directory.
+
+The mechanism will support:
+
+* Reuse: Extract on first-run, reuse on subsequent runs.
+* Upgrade: Each version of the app extracts to a unique location, supporting side-by-side use of multiple versions.
+* Uninstall: Users can identify and delete extracted files when the app is no longer needed.
+* Access control: Processes running with elevated access can extract to admin-only-writable locations.
+
+### 1.2 Scenarios
+
+Best suited for:
+
+* Environments requiring maximal compatibility -- need to embed different kinds of files (IL, native, etc) into one, without losing functionality such as debuggability.
+
+Limitations:
+
+* Unsuitable for environments that require that the app does not perform disk-writes at startup
+
+Advantages:
+
+* Low cost of development
+* Bundler tool can be used as-is for most further stages
+* Provides ability to develop test infrastructure and prototypes
+
+## 2. Run from Bundle: MSIL
+
+### 2.1 Description
+
+This stage improves on Stage 1 in that 
+
+* MSIL files bundled into the single-file will load and execute directly from the executable.
+* Native libraries will still need to 
+	* Remain in the publish directory unmerged, or
+	* Extracted to the disk like the previous self-extractor stage
+* Debugging support is unaffected. 
+
+### 2.2 Scenarios
+
+Best suited for:
+
+* Framework dependent purely managed apps that are not ready-to-run compiled.
+
+Limitations:
+
+* Unsuitable for environments that 
+	* Have native dependencies (ex: published `--self-contained`, or depend on custom native libraries), and 
+	* Cannot tolerate native libraries to remain unbundled or extracted to disk
+* The app may need to be aware that its dependencies will be embedded into the single-file, when using certain LoadLibrary APIs.
+
+## 3. Run from Bundle:  R2R
+
+### 3.1 Description
+
+In this stage
+
+* MSIL and Ready-to-run files bundled into the single-file will load and execute directly from the executable.
+* Native library support is the same as the previous stage.
+* Debugging support is unaffected. 
+
+### 3.2 Scenarios
+
+Best suited for:
+
+* Framework dependent managed apps that may be ready-to-run compiled.
+
+Limitations:
+
+* Unsuitable for environments that have native dependencies that must be bundled and cannot be extracted.
+
+## 4. Run from Bundle: .Net Core libraries 
+
+### 4.1 Description
+
+In this stage
+
+* .Net Core native libraries are statically linked to the single-file host executable.
+* Handling of custom native libraries is the same as the previous stage.
+* A large portion of the work involved in this stage is to make debuggers and tools compatible with the statically linked runtime.
+
+### 4.2 Scenarios
+
+Best suited for:
+
+* Self-contained managed apps
+
+Limitations:
+
+* Environments that have dependencies on custom native libries that must be bundled and cannot be extracted.
+* Watson dumps may not be supported.
+
+## 5. Run from Bundle: Native libraries
+
+### 5.1 Description
+
+This stage improves on the previous one by providing the ability to statically link custom native code along into the host executable. This involves:
+
+- Publishing the runtime as a library.
+- Provide tools and guidance to statically link user's native-code with the runtime library to obtain a custom host executable
+- Tooling to embed managed dependencies into this custom executable.
+
+ Debugging support is the same as the previous stage.
+
+Native library dependencies that cannot be statically linked will need to be extracted to the disk -- because some operating-systems do not support loading native libraries from memory.
+
+### 5.2 Scenarios
+
+Best suited for:
+
+* Self-contained managed apps with custom native dependencies (that can be linked).
+
+Limitations:
+
+* Watson dumps may not be supported.


### PR DESCRIPTION
The is a design proposal for supporting single file distribution in .Net Core.

To run apps published as a single-file, [CoreCLR#20287](https://github.com/dotnet/coreclr/issues/20287) proposed extracting out all the embedded dependencies to files at startup.

However, based on customer feedback through public and private fourms, the current design uses a hybrid of in-memory execution and extraction to files.

Further stages of improvements are outlined in `staging.md`.