### PR TITLE
Fix a setting wrt excluding files.

### DIFF
--- a/accepted/single-file/design.md
+++ b/accepted/single-file/design.md
@@ -115,7 +115,7 @@ For example, to place some files in the publish directory but not bundle them in
 <ItemGroup>
     <Content Update="*.xml">
       <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
-      <IncludeInSingleFile>PreserveNewest</IncludeInSingleFile>
+      <IncludeInSingleFile>Never</IncludeInSingleFile>
     </Content>
   </ItemGroup>
 ```


### PR DESCRIPTION
Fix a copy-setting in a sample for excluding certain
files in the publish directory from the single-file