### PR TITLE
Single-file: Add notes about accessing files from Bundle

### DIFF
--- a/accepted/single-file/design.md
+++ b/accepted/single-file/design.md
@@ -182,7 +182,7 @@ We need to determine the semantics of current APIs such as `Assembly.Location` t
 
 #### `Assembly.Location`
 
-`Assembly.Location`  for a bundled assembly could return:
+There are a few options to consider for the `Assembly.Location`  property of a bundled assembly:
 
 * A fixed literal (ex: `null`) indicating that no actual location is available.
 * The simple name of the assembly (with no path).
@@ -191,18 +191,25 @@ We need to determine the semantics of current APIs such as `Assembly.Location` t
 * In the case of files spilled to disk (ex: ready-to-run assemblies) -- the actual location of the extracted file.
 * A configurable selection of the above, etc.
 
-Most of the app development can be agnostic to whether the app is published as single-file or not. However, the parts of the app that deal with physical locations of files need to be aware of the single-file packaging. 
-
-In the first implementation, we propose keeping the default behavior of `Assembly.Location`. That is, 
+We propose keeping the default behavior of `Assembly.Location`. That is, 
 
 * If the assembly is loaded directly from the bundle, return empty-string
 * If the assembly is extracted to disk, return the location of the extracted file.
 
-The semantics of assembly location should be tuned further based on user feedback, and such that it aligns with other bundling technologies in .Net Core ecosystem.
+Most of the app development can be agnostic to whether the app is published as single-file or not. However, the parts of the app that deal with physical locations of files need to be aware of the single-file packaging. 
 
 #### `AppContext.BaseDirectory`
 
-If files are extracted out to disk, the `AppContext.BaseDirectory` is set to the directory where files are extracted. If all files in a bundle can be processed directly without need for extraction (an extraction directory is not created), and the `AppContext.BaseDirectory` is set to the directory where the AppHost resides.
+A few options to consider for the `AppContext.BaseDirectory` are:
+
+* The directory where embedded files are extracted out: This option enables easy access to content files spilled to disk. However, if no files need to be extracted to disk for an application bundle, there's no extraction directory. 
+* The extraction-directory if files are extracted, the AppHost directory otherwise. The limitation to this approach is that the value of  `AppContext.BaseDirectory`  changes with the way applications are packaged/executed.
+* The directory where `AppHost` binary resides (always).
+
+We propose that `AppContext.BaseDirectory`  should always be set to the directory where the `AppHost` bundle resides.  This scheme doesn't provide an obvious mechanism to access the contents of the extraction directory -- by design. The recommended method for accessing content files from the bundle are: 
+
+- Do not bundle application data files into the single-exe; instead them next to the bundle. This way, the application binary is a single-file, but not the whole application.
+- Embed data files as managed resources into application binary, and access them via resource management [APIs](<https://docs.microsoft.com/en-us/dotnet/api/system.reflection.assembly.getmanifestresourcestream?view=netcore-3.0>). 
 
 ## Testing
 

--- a/accepted/single-file/design.md
+++ b/accepted/single-file/design.md
@@ -143,10 +143,6 @@ On Startup, the AppHost checks if it has embedded files. If so, it
 
 An app may choose to only embed some files (ex: due to licensing restrictions) and expect to pickup other dependencies from application-launch directory, nuget packages, etc. In order to resolve assemblies and native libraries, the embedded resources are probed first, followed by other probing paths. 
 
-#### App_Root Setting
-
-If files are extracted out to disk, the corehost `App_Root` is set to the directory where files are extracted. If all files in a bundle can be processed directly without need for extraction (an extraction directory is not created), and the `App_Root` is set to the directory where the AppHost resides.
-
 ### New API
 
 In this section, we propose adding a few APIs to facilitate common operations on bundled-apps.
@@ -182,7 +178,11 @@ We can also provide an abstraction that abstracts away the physical location of 
 
 ### Existing API
 
-We need to determine the semantics of current APIs such as `Assembly.Location` that return the information about an assembly's location on disk. For example, `Assembly.Location`  for a bundled assembly could return:
+We need to determine the semantics of current APIs such as `Assembly.Location` that return the information about an assembly's location on disk. 
+
+#### `Assembly.Location`
+
+`Assembly.Location`  for a bundled assembly could return:
 
 * A fixed literal (ex: `null`) indicating that no actual location is available.
 * The simple name of the assembly (with no path).
@@ -199,6 +199,10 @@ In the first implementation, we propose keeping the default behavior of `Assembl
 * If the assembly is extracted to disk, return the location of the extracted file.
 
 The semantics of assembly location should be tuned further based on user feedback, and such that it aligns with other bundling technologies in .Net Core ecosystem.
+
+#### `AppContext.BaseDirectory`
+
+If files are extracted out to disk, the `AppContext.BaseDirectory` is set to the directory where files are extracted. If all files in a bundle can be processed directly without need for extraction (an extraction directory is not created), and the `AppContext.BaseDirectory` is set to the directory where the AppHost resides.
 
 ## Testing
 

--- a/accepted/single-file/design.md
+++ b/accepted/single-file/design.md
@@ -135,28 +135,17 @@ Once the single-file-publish tooling is added to the publish pipeline, other sta
 
 On Startup, the AppHost checks if it has embedded files. If so, it 
 
-* Processes configuration files such as `app.deps.json` , `app.runtimeconfig.json` from the embedded files, instead of looking for them on the disk next to the app.
-* Sets up the data-structures to locate pure managed assemblies within the bundle so that they can be loaded on-demand.
-* Extracts the other files (native libraries, ready-to-run compiled assemblies, and other data files to an *install-location*). Extraction of files is discussed in detail in this  [document](extract.md). 
-* Communicates the information about bundled and extracted files to the runtime, as explained in the section on dependency resolution.
+* Memory maps the entire bundle file.
+* Extracts the necessary files (ex: native binaries) to disk (if any) as explained in this [document](extract.md). 
+* Sets up data-structures so other components can access files embedded directly, as explained in this [document](direct.md)
 
 #### Dependency Resolution
 
 An app may choose to only embed some files (ex: due to licensing restrictions) and expect to pickup other dependencies from application-launch directory, nuget packages, etc. In order to resolve assemblies and native libraries, the embedded resources are probed first, followed by other probing paths. 
 
-The communication between the host and the runtime will continue to be through properties such as `TRUSTED_PLATFORM_ASSEMBLIES`, `NATIVE_DLL_SEARCH_DIRECTORIES`, etc.  These properties will be populated with entries from the bundled files (using a special marker) and the extracted files.
+#### App_Root Setting
 
-For example, if the TPA without single-exe publish is:
-`~/app/il.dll`; `~/app/r2r.dll`; `/usr/local/nuget/dep.dll`
-
-Where
-
-* `il.dll` is a pure managed assembly that is loaded directly from the bundle
-* `r2r.dll` is a ready-to-run assembly that is bundled and extract out to disk
-* `dep.dll` is an assembly that is not bundled with the app,
-
-the TPA with single-exe publish will be (assuming `?` is the bundle marker):
-`?/il.dll`; `/var/tmp/.net/app/e53xf3/r2r.dll`; `/usr/local/nuget/dep.dll`
+If files are extracted out to disk, the corehost `App_Root` is set to the directory where files are extracted. If all files in a bundle can be processed directly without need for extraction (an extraction directory is not created), and the `App_Root` is set to the directory where the AppHost resides.
 
 ### New API
 
@@ -197,7 +186,7 @@ We need to determine the semantics of current APIs such as `Assembly.Location` t
 
 * A fixed literal (ex: `null`) indicating that no actual location is available.
 * The simple name of the assembly (with no path).
-* A special UNC notation such as `//?/asm.dll` to denote files that come from the bundle. If multiple single-file bundles are used in an app (ex: plugins), this notation could be extended as `//?bundle-assembly/name.dll` -- if it is important to make a distinction with respect to which bundle an assembly came from.
+* A special UNC notation such as `<bundle-path>/:/asm.dll` to denote files that come from the bundle. 
 * The path of the assembly as if it were not to be packaged into the single-file.
 * In the case of files spilled to disk (ex: ready-to-run assemblies) -- the actual location of the extracted file.
 * A configurable selection of the above, etc.

--- a/accepted/single-file/direct.md
+++ b/accepted/single-file/direct.md
@@ -72,14 +72,7 @@ CORECLR_HOSTING_API(coreclr_register_bundle_reader,
                                           size_t* size));
 ```
 
-`HostPolicy` communicates the location of files residing within the bundle with a special bundle-marker (`:`) in the CoreCLR properties such as `TRUSTED_PLATFORM_ASSEMBLIES`.
+`HostPolicy` maintains a list of bundled assemblies internally, and communicates the assemblies on disk (unbundled or extracted) to the runtime in `TRUSTED_PLATFORM_ASSEMBLIES`.
 
-For example, if the bundle contains the following files:
+In order to resolve an assembly, the TPA-Binder first checks if it is available in the bundle (by invoking the `bundle_reader` callback). If the assembly is available in the bundle, the runtime loads the binary from memory via PELoader. If the assembly is not available in the bundle, the runtime continues to resolve it using the TPA-list.
 
-- `il.dll` is a pure managed assembly that is loaded directly from the bundle
-- `r2r.dll` is a ready-to-run assembly that is bundled and extract out to disk
-- `dep.dll` is an assembly that is not bundled with the app,
-
-The TPA will be set to `:il.dll`: `/var/tmp/.net/app/e53xf3/r2r.dll`: `/usr/local/nuget/dep.dll`
-
-If the runtime wants to load `il.dll`, it reads the contents of the file via the `bundle_reader` and loads the file using `PELoader`.

--- a/accepted/single-file/direct.md
+++ b/accepted/single-file/direct.md
@@ -80,6 +80,6 @@ For example, if the bundle contains the following files:
 - `r2r.dll` is a ready-to-run assembly that is bundled and extract out to disk
 - `dep.dll` is an assembly that is not bundled with the app,
 
-The TPA will be set to `:/il.dll`; `/var/tmp/.net/app/e53xf3/r2r.dll`; `/usr/local/nuget/dep.dll`
+The TPA will be set to `:il.dll`: `/var/tmp/.net/app/e53xf3/r2r.dll`: `/usr/local/nuget/dep.dll`
 
 If the runtime wants to load `il.dll`, it reads the contents of the file via the `bundle_reader` and loads the file using `PELoader`.

--- a/accepted/single-file/direct.md
+++ b/accepted/single-file/direct.md
@@ -1,0 +1,85 @@
+# Accessing Bundled Content
+
+This document outlines the process by which the host and runtime components access files embedded within a single-file bundle directly (that is, without extracting out to temporary files on disk).  
+
+### AppHost
+
+The AppHost bundle-handling code implements the following service, which will be registered for use by other components.
+
+```c++
+// If the requested file is available in the bundle, the function provides 
+//   - A pointer to a buffer with the contents of the file in memory 
+//   - The size of the file.
+// The function returns true if the file is found, false otherwise.
+static bool read_bundled_file(const char* name, 
+                              const void** buffer, 
+                              size_t* size);
+```
+
+### HostFxr
+
+The `Apphost` provides the a bundle-reader for `HostFxr` via the updated API:
+
+```C++
+SHARED_API int hostfxr_main_startupinfo(const int argc, 
+                                        const pal::char_t* argv[], 
+                                        const pal::char_t* host_path, 
+                                        const pal::char_t* dotnet_root,
+                                        const pal::char_t* app_path,
+                                        bool (*bundle_reader)(const char* name, 
+                                                              const void** buffer, 
+                                                              size_t* size));
+```
+
+The `HostFxr` uses this reader to read `app.runtimeconfig.json` and any other files it may need from the bundle. If the `bundle_reader` is invalid or fails to find the requested file, it falls back to look for an actual file on disk.
+
+### HostPolicy
+
+The `HostFxr` registers the `bundle_reader` with `HostPolicy` via the updated API:
+
+```C++
+struct corehost_initialize_request_t
+{
+    size_t version;
+    strarr_t config_keys;
+    strarr_t config_values;
+    bool (*bundle_reader)(const char* name, const void** buffer, size_t* size);
+};
+
+SHARED_API int __cdecl corehost_initialize(
+    const corehost_initialize_request_t *init_request, 
+    int32_t options,
+    /*out*/ corehost_context_contract *context_contract);
+```
+
+Host policy uses this reader to attempt to process the `app.deps.json` file and check for the existence of other component files within the bundle.
+
+### Runtime Components
+
+The `HostPolicy` registers the `bundle-reader` with the runtime via a new API: 
+
+```C++
+// Register a bundle-reader with CoreCLR
+//
+// Parameters:
+//  reader - The bundle-reader to use for this application
+// Returns:
+//  S_OK
+
+CORECLR_HOSTING_API(coreclr_register_bundle_reader,
+                    bool (*bundle_reader)(const char* name, 
+                                          const void** buffer, 
+                                          size_t* size));
+```
+
+`HostPolicy` communicates the location of files residing within the bundle with a special bundle-marker (`:`) in the CoreCLR properties such as `TRUSTED_PLATFORM_ASSEMBLIES`.
+
+For example, if the bundle contains the following files:
+
+- `il.dll` is a pure managed assembly that is loaded directly from the bundle
+- `r2r.dll` is a ready-to-run assembly that is bundled and extract out to disk
+- `dep.dll` is an assembly that is not bundled with the app,
+
+The TPA will be set to `:/il.dll`; `/var/tmp/.net/app/e53xf3/r2r.dll`; `/usr/local/nuget/dep.dll`
+
+If the runtime wants to load `il.dll`, it reads the contents of the file via the `bundle_reader` and loads the file using `PELoader`.


### PR DESCRIPTION
This change adds certain details about accessing the files
embedded within  asingle-file bundle without having to spill
them to files on disk.