### PR TITLE
Single-File: Extraction configurations as build-time properties.

### DIFF
--- a/accepted/single-file/extract.md
+++ b/accepted/single-file/extract.md
@@ -112,9 +112,14 @@ During startup, the Apphost:
 
 ### Extraction Configurations
 
-The following build-properties can be set to influence the extraction mechanism:
+The following settings can be used to configure the extraction mechanism:
 
-* `ExtractBaseDir` The base directory within which the files embedded in a single-file app are extracted, as explained in sections above. This directory can be set up an admin-only writable location if necessary.
-* `ExtractAllFiles`:  Extract all embedded dependencies in each run (instead of loading certain files directly from the bundle) .
+* Extract all embedded dependencies in each run (instead of loading certain files directly from the bundle) 
+  * Build time: Set the property `ExtractAllFiles= true`
+  * Run-time: Set the environment variable `DOTNET_BUNDLE_EXTRACT_ALL_FILES=true`
+* Set the base directory within which the files embedded in a single-file app are extracted, as explained in sections above. 
+  * Run-time: Set the `DOTNET_BUNDLE_EXTRACT_BASE_DIR` environment variable to the full path.
+  * There is no build-time configuration, since this is a path-setting on the machine where the app is run.
 
-Alternately, the environment variables `DOTNET_BUNDLE_EXTRACT_BASE_DIR`  and `DOTNET_BUNDLE_EXTRACT_ALL_FILES` can be set at run time, to achieve the effect of the configuration settings `ExtractBaseDir` and `ExtractAllFiles` respectively.  The environment variables are expected to be useful in debugging scenarios.
+The environment variables mentioned above are expected to be useful in debugging scenarios.
+

--- a/accepted/single-file/extract.md
+++ b/accepted/single-file/extract.md
@@ -112,7 +112,7 @@ During startup, the Apphost:
 
 ### Extraction Configurations
 
-The following switches can be set in the application configuration file (`runtimeconfig.json`) to influence the extraction mechanism:
+The following build-properties can be set to influence the extraction mechanism:
 
 * `ExtractBaseDir` The base directory within which the files embedded in a single-file app are extracted, as explained in sections above. This directory can be set up an admin-only writable location if necessary.
 * `ExtractAllFiles`:  Extract all embedded dependencies in each run (instead of loading certain files directly from the bundle) .


### PR DESCRIPTION
This commit changes the way the location where files in a bundle
are extracted can be influenced at build time.

Originally, they were written as properties in `runtimeconfig.json` file,
which is complex to handle at runtime, because the apphost needs to
extract resources before `hostfxr` process `runtimeconfig.json`
(because hostfxr itself needs to be extracted).

Instead the configurations are now build-time properties, which can be
written to and processed from the bundle-headers.