### PR TITLE
Propose method to dlopen() from memory

### DIFF
--- a/accepted/single-file/staging.md
+++ b/accepted/single-file/staging.md
@@ -126,7 +126,10 @@ This stage improves on the previous one by providing the ability to statically l
 
  Debugging support is the same as the previous stage.
 
-Native library dependencies that cannot be statically linked will need to be extracted to the disk -- because some operating-systems do not support loading native libraries from memory.
+For native library dependencies, there are two possible scenarios:
+
+- On systems where it's not possible to load them from memory, they'll have to be spilled out to disk, and loaded as usual with the standard method of loading shared libraries.
+- On Linux systems, it's possible to use `memfd_create()` to create an ephemeral file that's backed by an anonymous memory mapping.  If one writes the bundled shared library into that file and pass the ephemeral path (`/proc/self/fd/${FILE_DESCRIPTOR}`) to `dlopen()`, the file library should open as usual.  (Seals may be added with `fnctl()` for good measure.)
 
 ### 5.2 Scenarios
 


### PR DESCRIPTION
By using memfd_create(), it's possible to create a ephemeral file that's mapped by the same kind of backing store that a mmap() with MAP_ANONYMOUS would have.  It's possible to obtain a file path for this file in /proc and then feed it to dlopen().