### PR TITLE
Clarify behavior for Better Obsoletion

### DIFF
--- a/accepted/2020/better-obsoletion/better-obsoletion.md
+++ b/accepted/2020/better-obsoletion/better-obsoletion.md
@@ -237,9 +237,9 @@ follows:
   features, in other words both can be used, either, or neither.
 * If `UrlFormat` is provided without a `DiagnosticId` the compiler will use the
   `DiagnosticId` that it uses by default as the format argument to `UrlFormat`.
-  For C# this could be `CS0618`, `CS0619`, `CS1062`, or `CS1063`. The internal
-  error codes don't consider leading zeroes, but the padding is important when
-  we actually do the format substitution.
+  For C# this could be `CS0618`, for example, but will vary depending on context.
+  The internal error codes don't consider leading zeroes, but
+  the padding is important when we actually do the format substitution.
 * It's legal for `UrlFormat` to not contain a `{0}` placeholder, in which case
   the provided `UrlFormat` is treated as the final URL. If more than one format
   specifier is included, the compiler will ignore `UrlFormat` entirely.

--- a/accepted/2020/better-obsoletion/better-obsoletion.md
+++ b/accepted/2020/better-obsoletion/better-obsoletion.md
@@ -235,6 +235,14 @@ follows:
   them in the IDE.
 * The compiler should assume that `UrlFormat` and `DiagnosticId` are independent
   features, in other words both can be used, either, or neither.
+* If `UrlFormat` is provided without a `DiagnosticId` the compiler will use the
+  `DiagnosticId` that it uses by default as the format argument to `UrlFormat`.
+  For C# this could be `CS0618`, `CS0619`, `CS1062`, or `CS1063`. The internal
+  error codes don't consider leading zeroes, but the padding is important when
+  we actually do the format substitution.
+* It's legal for `UrlFormat` to not contain a `{0}` placeholder, in which case
+  the provided `UrlFormat` is treated as the final URL. If more than one format
+  specifier is included, the compiler will ignore `UrlFormat` entirely.
 
 ### Samples
 


### PR DESCRIPTION
@RikkiGibson [said this](https://github.com/dotnet/roslyn/issues/42119#issuecomment-599753623):

> A key bit of the spec, and how we are landing on it in terms of behavior:
> 
> > The compiler should assume that UrlFormat and DiagnosticId are independent features, in other words both can be used, either, or neither.
> 
> The expected behaviors for "neither", "both", or "only DiagnosticId provided" are fairly straightforward. But I wanted to be clear about the case where UrlFormat is provided but DiagnosticId is not provided: **we will use the DiagnosticId that the compiler chooses by default as the format argument to UrlFormat**. This could be `CS0618`, `CS0619`, `CS1062`, or `CS1063`. The internal error codes don't consider leading zeroes, but the padding is important when we actually do the format substitution.
> 
> When I write it out it seems pretty obvious 😄 but still good to record the expectation.

