### PR TITLE
use friendly name for project.assets.json

### DIFF
--- a/accepted/2020/net5/net5.md
+++ b/accepted/2020/net5/net5.md
@@ -538,8 +538,7 @@ TFMs should be returned in whatever encoding they are returned today.
 Concretely, this means the following:
 
 * `project.assets.json`
-    * **Always use friendly name**. This file doesn't need to be shared between
-      older SDK versions.
+    * **Use friendly name for .NET 5 and higher**
     * Eventually we'd like to update the format so that the keys to the target
       are not necessarily parseable TFMs, but can be arbitrary strings defined
       in the `<TargetFrameworks>` property. That would mean we'd need to store


### PR DESCRIPTION
Sorry, I didn't notice this didn't get changed after our last conversation. My understanding was that this was going to be how we handled -all- relevant files. I'm a bit hesitant about making the change as currently specified (I've already done this over at https://github.com/NuGet/NuGet.Client/pull/3339), but I notice we have some failing tests due to that. /cc @nkolev92 @rrelyea 

Anyway, this PR isn't a hard requirement, but a preference, if you think it's fine to do this for consistency and safety's sake, @terrajobst 