### PR TITLE
Add additional Windows-specific APIs

### DIFF
--- a/accepted/2020/windows-specific-apis/windows-specific-apis.md
+++ b/accepted/2020/windows-specific-apis/windows-specific-apis.md
@@ -698,11 +698,6 @@ Windows-specific:
 * **X509Chain**
     - `.ctor(IntPtr)`
 * **X509Certificate2UI**
-    - `.ctor()`
-    - `DisplayCertificate(X509Certificate2)`
-    - `DisplayCertificate(X509Certificate2, IntPtr)`
-    - `SelectFromCollection(X509Certificate2Collection, String, String, X509SelectionFlag)`
-    - `SelectFromCollection(X509Certificate2Collection, String, String, X509SelectionFlag, IntPtr)`
 
 ### System.ServiceModel
 

--- a/accepted/2020/windows-specific-apis/windows-specific-apis.md
+++ b/accepted/2020/windows-specific-apis/windows-specific-apis.md
@@ -89,6 +89,17 @@ Windows-specific:
 
 ### System
 
+* **ArgIterator**
+    - `.ctor(RuntimeArgumentHandle)`
+    - `.ctor(RuntimeArgumentHandle, Void*)`
+    - `End()`
+    - `Equals(Object)`
+    - `GetHashCode()`
+    - `GetNextArg()`
+    - `GetNextArg(RuntimeTypeHandle)`
+    - `GetNextArgType()`
+    - `GetRemainingCount()`
+
 * **Console**
     - `Beep(Int32, Int32)`
     - `get_CapsLock()`
@@ -112,10 +123,310 @@ Windows-specific:
 
 * **DpapiProtectedConfigurationProvider**
 
+### System.Data.SqlTypes
+
+* **SqlFileStream**
+    - `Flush()`
+    - `get_Name()`
+    - `Read(Byte[], Int32, Int32)`
+    - `Write(Byte[], Int32, Int32)`
+    - `.ctor(String, Byte[], FileAccess)`
+    - `.ctor(String, Byte[], FileAccess, FileOptions, Int64)`
+    - `get_CanRead()`
+    - `get_CanSeek()`
+    - `get_CanWrite()`
+    - `get_Length()`
+    - `get_Position()`
+    - `get_TransactionContext()`
+    - `Seek(Int64, SeekOrigin)`
+    - `set_Position(Int64)`
+    - `SetLength(Int64)`
+
+### System.Data.OleDb
+
+* **OleDbCommand**
+    - `.ctor()`
+    - `.ctor(String)`
+    - `Cancel()`
+    - `Clone()`
+    - `get_Parameters()`
+    - `System.ICloneable.Clone()`
+    - `.ctor(String, OleDbConnection)`
+    - `.ctor(String, OleDbConnection, OleDbTransaction)`
+    - `CreateParameter()`
+    - `ExecuteNonQuery()`
+    - `ExecuteReader()`
+    - `ExecuteReader(CommandBehavior)`
+    - `ExecuteScalar()`
+    - `get_CommandText()`
+    - `get_CommandTimeout()`
+    - `get_CommandType()`
+    - `get_Connection()`
+    - `get_DesignTimeVisible()`
+    - `get_Transaction()`
+    - `get_UpdatedRowSource()`
+    - `Prepare()`
+    - `ResetCommandTimeout()`
+    - `set_CommandText(String)`
+    - `set_CommandTimeout(Int32)`
+    - `set_CommandType(CommandType)`
+    - `set_Connection(OleDbConnection)`
+    - `set_DesignTimeVisible(Boolean)`
+    - `set_Transaction(OleDbTransaction)`
+    - `set_UpdatedRowSource(UpdateRowSource)`
+    - `System.Data.IDbCommand.ExecuteReader()`
+    - `System.Data.IDbCommand.ExecuteReader(CommandBehavior)`
+* **OleDbCommandBuilder**
+    - `.ctor()`
+    - `.ctor(OleDbDataAdapter)`
+    - `DeriveParameters(OleDbCommand)`
+    - `get_DataAdapter()`
+    - `GetDeleteCommand()`
+    - `GetDeleteCommand(Boolean)`
+    - `GetInsertCommand()`
+    - `GetInsertCommand(Boolean)`
+    - `GetUpdateCommand()`
+    - `GetUpdateCommand(Boolean)`
+    - `QuoteIdentifier(String)`
+    - `QuoteIdentifier(String, OleDbConnection)`
+    - `set_DataAdapter(OleDbDataAdapter)`
+    - `UnquoteIdentifier(String)`
+    - `UnquoteIdentifier(String, OleDbConnection)`
+* **OleDbConnection**
+    - `.ctor()`
+    - `.ctor(String)`
+    - `Close()`
+    - `get_Provider()`
+    - `Open()`
+    - `System.ICloneable.Clone()`
+    - `BeginTransaction()`
+    - `BeginTransaction(IsolationLevel)`
+    - `ChangeDatabase(String)`
+    - `CreateCommand()`
+    - `EnlistTransaction(Transaction)`
+    - `get_ConnectionString()`
+    - `get_ConnectionTimeout()`
+    - `get_Database()`
+    - `get_DataSource()`
+    - `get_ServerVersion()`
+    - `get_State()`
+    - `GetOleDbSchemaTable(Guid, Object[])`
+    - `GetSchema()`
+    - `GetSchema(String)`
+    - `GetSchema(String, String[])`
+    - `ReleaseObjectPool()`
+    - `ResetState()`
+    - `set_ConnectionString(String)`
+* **OleDbConnectionStringBuilder**
+    - `.ctor()`
+    - `.ctor(String)`
+    - `Clear()`
+    - `get_Item(String)`
+    - `get_Keys()`
+    - `get_Provider()`
+    - `Remove(String)`
+    - `set_Item(String, Object)`
+    - `get_DataSource()`
+    - `ContainsKey(String)`
+    - `get_FileName()`
+    - `get_OleDbServices()`
+    - `get_PersistSecurityInfo()`
+    - `set_DataSource(String)`
+    - `set_FileName(String)`
+    - `set_OleDbServices(Int32)`
+    - `set_PersistSecurityInfo(Boolean)`
+    - `set_Provider(String)`
+    - `TryGetValue(String, Object)`
+* **OleDbDataAdapter**
+    - `.ctor()`
+    - `.ctor(String, String)`
+    - `System.ICloneable.Clone()`
+    - `.ctor(String, OleDbConnection)`
+    - `.ctor(OleDbCommand)`
+    - `Fill(DataSet, Object, String)`
+    - `Fill(DataTable, Object)`
+    - `get_DeleteCommand()`
+    - `get_InsertCommand()`
+    - `get_SelectCommand()`
+    - `get_UpdateCommand()`
+    - `set_DeleteCommand(OleDbCommand)`
+    - `set_InsertCommand(OleDbCommand)`
+    - `set_SelectCommand(OleDbCommand)`
+    - `set_UpdateCommand(OleDbCommand)`
+    - `System.Data.IDbDataAdapter.get_DeleteCommand()`
+    - `System.Data.IDbDataAdapter.get_InsertCommand()`
+    - `System.Data.IDbDataAdapter.get_SelectCommand()`
+    - `System.Data.IDbDataAdapter.get_UpdateCommand()`
+    - `System.Data.IDbDataAdapter.set_DeleteCommand(IDbCommand)`
+    - `System.Data.IDbDataAdapter.set_InsertCommand(IDbCommand)`
+    - `System.Data.IDbDataAdapter.set_SelectCommand(IDbCommand)`
+    - `System.Data.IDbDataAdapter.set_UpdateCommand(IDbCommand)`
+* **OleDbDataReader**
+    - `Close()`
+    - `get_Item(Int32)`
+    - `get_Item(String)`
+    - `GetEnumerator()`
+    - `get_Depth()`
+    - `get_FieldCount()`
+    - `get_HasRows()`
+    - `get_IsClosed()`
+    - `get_RecordsAffected()`
+    - `get_VisibleFieldCount()`
+    - `GetBoolean(Int32)`
+    - `GetByte(Int32)`
+    - `GetBytes(Int32, Int64, Byte[], Int32, Int32)`
+    - `GetChar(Int32)`
+    - `GetChars(Int32, Int64, Char[], Int32, Int32)`
+    - `GetData(Int32)`
+    - `GetDataTypeName(Int32)`
+    - `GetDateTime(Int32)`
+    - `GetDecimal(Int32)`
+    - `GetDouble(Int32)`
+    - `GetFieldType(Int32)`
+    - `GetFloat(Int32)`
+    - `GetGuid(Int32)`
+    - `GetInt16(Int32)`
+    - `GetInt32(Int32)`
+    - `GetInt64(Int32)`
+    - `GetName(Int32)`
+    - `GetOrdinal(String)`
+    - `GetSchemaTable()`
+    - `GetString(Int32)`
+    - `GetTimeSpan(Int32)`
+    - `GetValue(Int32)`
+    - `GetValues(Object[])`
+    - `IsDBNull(Int32)`
+    - `NextResult()`
+    - `Read()`
+* **OleDbEnumerator**
+    - `.ctor()`
+    - `GetElements()`
+    - `GetEnumerator(Type)`
+    - `GetRootEnumerator()`
+* **OleDbError**
+    - `get_Message()`
+    - `get_Source()`
+    - `ToString()`
+    - `get_NativeError()`
+    - `get_SQLState()`
+* **OleDbErrorCollection**
+    - `CopyTo(Array, Int32)`
+    - `get_Count()`
+    - `get_Item(Int32)`
+    - `GetEnumerator()`
+    - `System.Collections.ICollection.get_IsSynchronized()`
+    - `System.Collections.ICollection.get_SyncRoot()`
+    - `CopyTo(OleDbError[], Int32)`
+* **OleDbException**
+    - `get_ErrorCode()`
+    - `GetObjectData(SerializationInfo, StreamingContext)`
+    - `get_Errors()`
+* **OleDbFactory**
+    - `CreateParameter()`
+    - `CreateCommand()`
+    - `CreateCommandBuilder()`
+    - `CreateConnection()`
+    - `CreateConnectionStringBuilder()`
+    - `CreateDataAdapter()`
+* **OleDbInfoMessageEventArgs**
+    - `get_ErrorCode()`
+    - `get_Message()`
+    - `get_Source()`
+    - `ToString()`
+    - `get_Errors()`
+* **OleDbParameter**
+    - `.ctor()`
+    - `get_Direction()`
+    - `get_Value()`
+    - `set_Value(Object)`
+    - `System.ICloneable.Clone()`
+    - `ToString()`
+    - `.ctor(String, OleDbType)`
+    - `.ctor(String, OleDbType, Int32)`
+    - `.ctor(String, OleDbType, Int32, ParameterDirection, Boolean, Byte, Byte, String, DataRowVersion, Object)`
+    - `.ctor(String, OleDbType, Int32, ParameterDirection, Byte, Byte, String, DataRowVersion, Boolean, Object)`
+    - `.ctor(String, OleDbType, Int32, String)`
+    - `.ctor(String, Object)`
+    - `get_DbType()`
+    - `get_IsNullable()`
+    - `get_OleDbType()`
+    - `get_ParameterName()`
+    - `get_Precision()`
+    - `get_Scale()`
+    - `get_Size()`
+    - `get_SourceColumn()`
+    - `get_SourceColumnNullMapping()`
+    - `get_SourceVersion()`
+    - `ResetDbType()`
+    - `ResetOleDbType()`
+    - `set_DbType(DbType)`
+    - `set_Direction(ParameterDirection)`
+    - `set_IsNullable(Boolean)`
+    - `set_OleDbType(OleDbType)`
+    - `set_ParameterName(String)`
+    - `set_Precision(Byte)`
+    - `set_Scale(Byte)`
+    - `set_Size(Int32)`
+    - `set_SourceColumn(String)`
+    - `set_SourceColumnNullMapping(Boolean)`
+    - `set_SourceVersion(DataRowVersion)`
+* **OleDbParameterCollection**
+    - `Add(Object)`
+    - `Add(String, Object)`
+    - `Clear()`
+    - `Contains(Object)`
+    - `Contains(String)`
+    - `CopyTo(Array, Int32)`
+    - `get_Count()`
+    - `get_IsFixedSize()`
+    - `get_IsReadOnly()`
+    - `get_IsSynchronized()`
+    - `get_Item(Int32)`
+    - `get_Item(String)`
+    - `get_SyncRoot()`
+    - `GetEnumerator()`
+    - `IndexOf(Object)`
+    - `IndexOf(String)`
+    - `Insert(Int32, Object)`
+    - `Remove(Object)`
+    - `RemoveAt(Int32)`
+    - `Add(OleDbParameter)`
+    - `Add(String, OleDbType)`
+    - `Add(String, OleDbType, Int32)`
+    - `Add(String, OleDbType, Int32, String)`
+    - `AddRange(Array)`
+    - `AddRange(OleDbParameter[])`
+    - `AddWithValue(String, Object)`
+    - `Contains(OleDbParameter)`
+    - `CopyTo(OleDbParameter[], Int32)`
+    - `IndexOf(OleDbParameter)`
+    - `Insert(Int32, OleDbParameter)`
+    - `Remove(OleDbParameter)`
+    - `RemoveAt(String)`
+    - `set_Item(Int32, OleDbParameter)`
+    - `set_Item(String, OleDbParameter)`
+* **OleDbRowUpdatedEventArgs**
+    - `.ctor(DataRow, IDbCommand, StatementType, DataTableMapping)`
+    - `get_Command()`
+* **OleDbRowUpdatingEventArgs**
+    - `.ctor(DataRow, IDbCommand, StatementType, DataTableMapping)`
+    - `get_Command()`
+    - `set_Command(OleDbCommand)`
+* **OleDbSchemaGuid**
+    - `.ctor()`
+* **OleDbTransaction**
+    - `get_Connection()`
+    - `Begin()`
+    - `Begin(IsolationLevel)`
+    - `Commit()`
+    - `get_IsolationLevel()`
+    - `Rollback()`
+
 ### System.Diagnostics
 
 * **Process**
     - `EnterDebugMode()`
+    - `Kill(Boolean)`
     - `LeaveDebugMode()`
     - `set_MaxWorkingSet(IntPtr)`
     - `set_MinWorkingSet(IntPtr)`
@@ -134,10 +445,72 @@ Windows-specific:
     - `set_PriorityLevel(ThreadPriorityLevel)`
     - `set_ProcessorAffinity(IntPtr)`
 
+### System.Drawing
+
+* **FontConverter**
+    - `.ctor()`
+    - `CanConvertFrom(ITypeDescriptorContext, Type)`
+    - `CanConvertTo(ITypeDescriptorContext, Type)`
+    - `ConvertFrom(ITypeDescriptorContext, CultureInfo, Object)`
+    - `ConvertTo(ITypeDescriptorContext, CultureInfo, Object, Type)`
+    - `CreateInstance(ITypeDescriptorContext, IDictionary)`
+    - `GetCreateInstanceSupported(ITypeDescriptorContext)`
+    - `GetProperties(ITypeDescriptorContext, Object, Attribute[])`
+    - `GetPropertiesSupported(ITypeDescriptorContext)`
+* **FontConverter+FontNameConverter**
+    - `.ctor()`
+    - `CanConvertFrom(ITypeDescriptorContext, Type)`
+    - `ConvertFrom(ITypeDescriptorContext, CultureInfo, Object)`
+    - `GetStandardValues(ITypeDescriptorContext)`
+    - `GetStandardValuesExclusive(ITypeDescriptorContext)`
+    - `GetStandardValuesSupported(ITypeDescriptorContext)`
+* **FontConverter+FontUnitConverter**
+    - `.ctor()`
+    - `GetStandardValues(ITypeDescriptorContext)`
+* **IconConverter**
+    - `.ctor()`
+    - `CanConvertFrom(ITypeDescriptorContext, Type)`
+    - `CanConvertTo(ITypeDescriptorContext, Type)`
+    - `ConvertFrom(ITypeDescriptorContext, CultureInfo, Object)`
+    - `ConvertTo(ITypeDescriptorContext, CultureInfo, Object, Type)`
+* **ImageConverter**
+    - `.ctor()`
+    - `CanConvertFrom(ITypeDescriptorContext, Type)`
+    - `CanConvertTo(ITypeDescriptorContext, Type)`
+    - `ConvertFrom(ITypeDescriptorContext, CultureInfo, Object)`
+    - `ConvertTo(ITypeDescriptorContext, CultureInfo, Object, Type)`
+    - `GetProperties(ITypeDescriptorContext, Object, Attribute[])`
+    - `GetPropertiesSupported(ITypeDescriptorContext)`
+* **ImageFormatConverter**
+    - `.ctor()`
+    - `CanConvertFrom(ITypeDescriptorContext, Type)`
+    - `CanConvertTo(ITypeDescriptorContext, Type)`
+    - `ConvertFrom(ITypeDescriptorContext, CultureInfo, Object)`
+    - `ConvertTo(ITypeDescriptorContext, CultureInfo, Object, Type)`
+    - `GetStandardValues(ITypeDescriptorContext)`
+    - `GetStandardValuesSupported(ITypeDescriptorContext)`
+
+### System.Drawing.Printing
+
+* **MarginsConverter**
+    - `.ctor()`
+    - `CanConvertFrom(ITypeDescriptorContext, Type)`
+    - `CanConvertTo(ITypeDescriptorContext, Type)`
+    - `ConvertFrom(ITypeDescriptorContext, CultureInfo, Object)`
+    - `ConvertTo(ITypeDescriptorContext, CultureInfo, Object, Type)`
+    - `CreateInstance(ITypeDescriptorContext, IDictionary)`
+    - `GetCreateInstanceSupported(ITypeDescriptorContext)`
+
 ### System.IO
 
 * **DriveInfo**
     - `set_VolumeLabel(String)`
+* **File**
+    - `Decrypt(String)`
+    - `Encrypt(String)`
+* **FileInfo**
+    - `Decrypt()`
+    - `Encrypt()`
 
 ### System.IO.MemoryMappedFiles
 
@@ -151,6 +524,10 @@ Windows-specific:
 
 ### System.IO.Pipes
 
+* **AnonymousPipeServerStreamAcl**
+    - `Create(PipeDirection, HandleInheritability, Int32, PipeSecurity)`
+* **NamedPipeServerStreamAcl**
+    - `Create(String, PipeDirection, Int32, PipeTransmissionMode, PipeOptions, Int32, Int32, PipeSecurity, HandleInheritability, PipeAccessRights)`
 * **NamedPipeClientStream**
     - `Connect(Int32)`
     - `get_NumberOfServerInstances()`
@@ -161,6 +538,39 @@ Windows-specific:
 * **PipeTransmissionMode**
     - `Message`
 
+### System.Media
+
+* **SoundPlayer**
+    - `.ctor()`
+    - `.ctor(String)`
+    - `Stop()`
+    - `.ctor(Stream)`
+    - `get_IsLoadCompleted()`
+    - `get_LoadTimeout()`
+    - `get_SoundLocation()`
+    - `get_Stream()`
+    - `get_Tag()`
+    - `Load()`
+    - `LoadAsync()`
+    - `OnLoadCompleted(AsyncCompletedEventArgs)`
+    - `OnSoundLocationChanged(EventArgs)`
+    - `OnStreamChanged(EventArgs)`
+    - `Play()`
+    - `PlayLooping()`
+    - `PlaySync()`
+    - `set_LoadTimeout(Int32)`
+    - `set_SoundLocation(String)`
+    - `set_Stream(Stream)`
+    - `set_Tag(Object)`
+* **SystemSound**
+    - `Play()`
+* **SystemSounds**
+    - `get_Asterisk()`
+    - `get_Beep()`
+    - `get_Exclamation()`
+    - `get_Hand()`
+    - `get_Question()`
+
 ### System.Net
 
 * **HttpListenerTimeoutManager**
@@ -168,6 +578,11 @@ Windows-specific:
     - `set_HeaderWait(TimeSpan)`
     - `set_MinSendBytesPerSecond(Int64)`
     - `set_RequestQueue(TimeSpan)`
+
+### System.Net.NetworkInformation
+
+* **Ping**
+    - `Send(IPAddress, Int32, Byte[], PingOptions)`
 
 ### System.Net.Sockets
 
@@ -204,8 +619,11 @@ Windows-specific:
     - `AddMulticastGroupOnInterface`
     - `DeleteMulticastGroupFromInterface`
 * **Socket**
+    - `.ctor(SocketInformation)`
+    - `.ctor(SafeSocketHandle)`
     - `SetIPProtectionLevel(IPProtectionLevel)`
     - `DuplicateAndClose`
+    - `DuplicateAndClose(Int32)`
 * **TcpListener**
     - `AllowNatTraversal(Boolean)`
 * **TransmitFileOptions**
@@ -214,10 +632,18 @@ Windows-specific:
     - `WriteBehind`
 * **UdpClient**
     - `AllowNatTraversal(Boolean)`
+    - `ReceiveAsync()`
 
 ### System.Runtime.InteropServices
 
+* **ComAwareEventInfo**
+    - `AddEventHandler(Object, Delegate)`
+    - `RemoveEventHandler(Object, Delegate)`
+* **ComEventsHelper**
+    - `Combine(Object, Guid, Int32, Delegate)`
+    - `Remove(Object, Guid, Int32, Delegate)`
 * **DispatchWrapper**
+    - `.ctor(Object)`
     - `get_WrappedObject()`
 * **Marshal**
     - `AddRef(IntPtr)`
@@ -252,6 +678,15 @@ Windows-specific:
     - `ReleaseComObject(Object)`
     - `ReleaseComObject(Object)`
     - `SetComObjectData(object,object,object)`
+* **ComWrappers+ComInterfaceDispatch**
+    - `GetInstance<T>(ComInterfaceDispatch*)`
+* **ComWrappers**
+    - `GetIUnknownImpl(IntPtr, IntPtr, IntPtr)`
+    - `GetOrCreateComInterfaceForObject(Object, CreateComInterfaceFlags)`
+    - `GetOrCreateObjectForComInstance(IntPtr, CreateObjectFlags)`
+    - `GetOrRegisterObjectForComInstance(IntPtr, CreateObjectFlags, Object)`
+    - `RegisterForMarshalling(ComWrappers)`
+    - `RegisterForTrackerSupport(ComWrappers)`
 
 ### System.Security.Cryptography
 
@@ -274,6 +709,12 @@ Windows-specific:
 
 * **X509Chain**
     - `.ctor(IntPtr)`
+* **X509Certificate2UI**
+    - `.ctor()`
+    - `DisplayCertificate(X509Certificate2)`
+    - `DisplayCertificate(X509Certificate2, IntPtr)`
+    - `SelectFromCollection(X509Certificate2Collection, String, String, X509SelectionFlag)`
+    - `SelectFromCollection(X509Certificate2Collection, String, String, X509SelectionFlag, IntPtr)`
 
 ### System.ServiceModel
 
@@ -397,3 +838,62 @@ Windows-specific:
     - `TryOpenExisting(String, Semaphore)`
 * **Thread**
     - `SetApartmentState(ApartmentState)`
+
+### System.Xaml.Permissions
+
+* **XamlAccessLevel**
+    - `AssemblyAccessTo(Assembly)`
+    - `AssemblyAccessTo(AssemblyName)`
+    - `get_AssemblyAccessToAssemblyName()`
+    - `get_PrivateAccessToTypeName()`
+    - `PrivateAccessTo(String)`
+    - `PrivateAccessTo(Type)`
+
+### Microsoft.VisualBasic
+
+* **DateAndTime**
+    - `set_DateString(String)`
+    - `set_TimeOfDay(DateTime)`
+    - `set_TimeString(String)`
+    - `set_Today(DateTime)`
+* **FileSystem**
+    - `ChDrive(Char)`
+    - `ChDrive(String)`
+    - `CurDir(Char)`
+    - `Dir(String, FileAttribute)`
+    - `Rename(String, String)`
+* **Interaction**
+    - `Beep()`
+    - `DeleteSetting(String, String, String)`
+    - `GetAllSettings(String, String)`
+    - `GetObject(String, String)`
+    - `GetSetting(String, String, String, String)`
+    - `SaveSetting(String, String, String, String)`
+* **Strings**
+    - `StrConv(String, VbStrConv, Int32)`
+
+### Microsoft.VisualBasic.FileIO
+
+* **FileSystem**
+    - `CopyDirectory(String, String)`
+    - `CopyDirectory(String, String, UIOption)`
+    - `CopyDirectory(String, String, UIOption, UICancelOption)`
+    - `CopyDirectory(String, String, Boolean)`
+    - `CopyFile(String, String)`
+    - `CopyFile(String, String, UIOption)`
+    - `CopyFile(String, String, UIOption, UICancelOption)`
+    - `CopyFile(String, String, Boolean)`
+    - `DeleteDirectory(String, DeleteDirectoryOption)`
+    - `DeleteDirectory(String, UIOption, RecycleOption)`
+    - `DeleteDirectory(String, UIOption, RecycleOption, UICancelOption)`
+    - `DeleteFile(String)`
+    - `DeleteFile(String, UIOption, RecycleOption)`
+    - `DeleteFile(String, UIOption, RecycleOption, UICancelOption)`
+    - `MoveDirectory(String, String)`
+    - `MoveDirectory(String, String, UIOption)`
+    - `MoveDirectory(String, String, UIOption, UICancelOption)`
+    - `MoveDirectory(String, String, Boolean)`
+    - `MoveFile(String, String)`
+    - `MoveFile(String, String, UIOption)`
+    - `MoveFile(String, String, UIOption, UICancelOption)`
+    - `MoveFile(String, String, Boolean)`

--- a/accepted/2020/windows-specific-apis/windows-specific-apis.md
+++ b/accepted/2020/windows-specific-apis/windows-specific-apis.md
@@ -89,17 +89,6 @@ Windows-specific:
 
 ### System
 
-* **ArgIterator**
-    - `.ctor(RuntimeArgumentHandle)`
-    - `.ctor(RuntimeArgumentHandle, Void*)`
-    - `End()`
-    - `Equals(Object)`
-    - `GetHashCode()`
-    - `GetNextArg()`
-    - `GetNextArg(RuntimeTypeHandle)`
-    - `GetNextArgType()`
-    - `GetRemainingCount()`
-
 * **Console**
     - `Beep(Int32, Int32)`
     - `get_CapsLock()`

--- a/accepted/2020/windows-specific-apis/windows-specific-apis.md
+++ b/accepted/2020/windows-specific-apis/windows-specific-apis.md
@@ -16,13 +16,25 @@ The lowest version of Windows that we support with .NET Core is Windows 7. Also,
 we generally don't expose functionality that requires a higher version of
 Windows.
 
-Thus, I propose that we use `7.0` as the minimum version number instead of
-hunting down which Windows version actually introduced a given feature, which
-means the custom attribute will look as follows:
+We originally said we'll mark these APIs as `windows7.0` but this would mean
+that callers have to call guard these APIs with `7.0` version check too, which
+isn't really necessary. But what's worse is that many developers already have
+written code that checks for the OS but not version, and due to the version
+support that is perfectly correct code.
+
+We decided that it's better for our analyzer to special case version-less checks
+and let it be equivalent of a check for `0.0`. We also decided that applying the
+attribute without a version is the same as stating the API was introduced in
+`0.0`. The net effect is that consumers of the existing Windows-specific APIs
+will get away with just checking for the OS.
 
 ```C#
-[MinimumOSPlatform("windows7.0")]
+[SupportedOSPlatform("windows")]
 ```
+
+Moving forward, we'll only tag Windows-specific APIs without version if they are
+supported by Windows 7 or earlier. APIs requiring newer OS versions will be
+marked with the corresponding OS version.
 
 ## .NET Standard 2.0 assemblies
 

--- a/accepted/2020/windows-specific-apis/windows-specific-apis.md
+++ b/accepted/2020/windows-specific-apis/windows-specific-apis.md
@@ -611,7 +611,6 @@ Windows-specific:
     - `.ctor(SocketInformation)`
     - `.ctor(SafeSocketHandle)`
     - `SetIPProtectionLevel(IPProtectionLevel)`
-    - `DuplicateAndClose`
     - `DuplicateAndClose(Int32)`
 * **TcpListener**
     - `AllowNatTraversal(Boolean)`


### PR DESCRIPTION
I made a mistake when I ran this tool last time -- I didn't clean my build. The result is that the previous state was based on .NET Core 3.1. This brings it forward to .NET 5 Preview 6.