### PR TITLE
Fix typo

### DIFF
--- a/accepted/2020/platform-checks/platform-checks.md
+++ b/accepted/2020/platform-checks/platform-checks.md
@@ -484,7 +484,7 @@ provides here is educational and avoids having to lookup the correct version
 numbers.
 
 For diagnostic (1) we should also offer a fixer that allows it to be marked as
-platform specific by applying `AddedInOSPlatformVersionAttribute`. If the
+platform specific by applying `SupportedOSPlatformAttribute`. If the
 attribute is already applied, it should offer to change the platform and
 version.
 


### PR DESCRIPTION
AddedInOSPlatformVersionAttribute was renamed in a previous commit, so
we should refer to its current name SupportedOSPlatformAttribute.