### PR TITLE
Fixed example links in proposal template

### DIFF
--- a/meta/template.md
+++ b/meta/template.md
@@ -12,8 +12,8 @@ check out [this document](proposals.md).
 
 ## Examples
 
-* [Windows Compatibility Pack](https://github.com/dotnet/designs/blob/master/accepted/compat-pack/compat-pack.md)
-* [Package Information in API Reference](https://github.com/dotnet/designs/blob/master/accepted/package-doc/package-doc.md)
+* [Windows Compatibility Pack](../accepted/2018/compat-pack/compat-pack.md)
+* [Package Information in API Reference](../accepted/2018/package-doc/package-doc.md)
 
 ## Template with Instructions
 


### PR DESCRIPTION
I also noticed the link to the ASP.NET Designs repo in the readme (https://github.com/aspnet/specs) is dead, but I'm not sure where  it was moved to. (Or maybe it's just private?)