### PR TITLE
Removed internal-only link to the ASP.NET specs repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 This repo contains [design proposals](meta/proposals.md) for the .NET platform.
 It focuses on designs for the runtime, framework, and the SDK. For others, see:
 
-* [ASP.NET Designs](https://github.com/aspnet/specs)
 * [C# Language Designs (dotnet/csharplang)](https://github.com/dotnet/csharplang)
 * [VB Language Designs (dotnet/vblang)](https://github.com/dotnet/vblang)
 * [F# Language Designs (fsharp/fslang-design)](https://github.com/fsharp/fslang-design)


### PR DESCRIPTION
As requested in https://github.com/dotnet/designs/pull/166#issuecomment-733954027

Part of me wonders if maybe we should just mark it as internal, but I suppose anyone who needs to know about that repo already does.