### PR TITLE
Adding the skeleton for statics-in-interfaces

### DIFF
--- a/accepted/2021/statics-in-interfaces/README.md
+++ b/accepted/2021/statics-in-interfaces/README.md
@@ -1,0 +1,14 @@
+# Statics in Interfaces
+
+**DRAFT**
+
+**Libraries PM** [Immo Landwerth](https://github.com/terrajobst)
+**Language PM** [Mads Torgersen](https://github.com/MadsTorgersen)
+
+C# is looking at enabling static abstract members in interfaces (https://github.com/dotnet/csharplang/issues/4436). From the libraries perspective, this is an opportunity to enable "generic math" which could define a new baseline for how developers write algorithms in .NET.
+
+## [Designs](designs/README.md)
+
+## [Requirements](requirements/README.md)
+
+## [Scenarios](scenarios/README.md)

--- a/accepted/2021/statics-in-interfaces/designs/README.md
+++ b/accepted/2021/statics-in-interfaces/designs/README.md
@@ -1,0 +1,6 @@
+# Designs
+
+**DRAFT**
+
+**Libraries PM** [Immo Landwerth](https://github.com/terrajobst)
+**Language PM** [Mads Torgersen](https://github.com/MadsTorgersen)

--- a/accepted/2021/statics-in-interfaces/requirements/README.md
+++ b/accepted/2021/statics-in-interfaces/requirements/README.md
@@ -1,0 +1,6 @@
+# Requirements
+
+**DRAFT**
+
+**Libraries PM** [Immo Landwerth](https://github.com/terrajobst)
+**Language PM** [Mads Torgersen](https://github.com/MadsTorgersen)

--- a/accepted/2021/statics-in-interfaces/scenarios/README.md
+++ b/accepted/2021/statics-in-interfaces/scenarios/README.md
@@ -1,0 +1,6 @@
+# Scenarios
+
+**DRAFT**
+
+**Libraries PM** [Immo Landwerth](https://github.com/terrajobst)
+**Language PM** [Mads Torgersen](https://github.com/MadsTorgersen)


### PR DESCRIPTION
CC. @terrajobst, @MadsTorgersen 

This is the skeleton (following the same template as for utf8) for the statics-in-interfaces/generic-math design for the libraries.