### PR TITLE
Specify that TFV includes the 'v' prefix on it's value, and also fix comparisons to use msbuild functions instead.

### DIFF
--- a/accepted/2020/net5/net5.md
+++ b/accepted/2020/net5/net5.md
@@ -1042,7 +1042,7 @@ And to check for things before a specific version do a comparison like this:
 
 If we had used ``TargetFrameworkVersion`` instead of ``_TargetFrameworkVersionWithoutV`` we would see this error for both conditions:
 
-````error MSB4086: A numeric comparison was attempted on "$(TargetFrameworkVersion)" that evaluates to "v3.0" instead of a number, in condition "'$(TargetFrameworkIdentifier)' == '.NETCoreApp' AND '$(_TargetFrameworkVersionWithoutV)' >= '3.0'".````
+``error MSB4086: A numeric comparison was attempted on "$(TargetFrameworkVersion)" that evaluates to "v3.0" instead of a number, in condition "'$(TargetFrameworkIdentifier)' == '.NETCoreApp' AND '$(_TargetFrameworkVersionWithoutV)' >= '3.0'".``
 ``error MSB4086: A numeric comparison was attempted on "$(TargetFrameworkVersion)" that evaluates to "v3.0" instead of a number, in condition "'$(TargetFrameworkIdentifier)' == '.NETCoreApp' AND '$(_TargetFrameworkVersionWithoutV)' &lt; '3.0'".``
 
 By us mapping `net5.0` we break less of that code because existing code will

--- a/accepted/2020/net5/net5.md
+++ b/accepted/2020/net5/net5.md
@@ -1024,13 +1024,13 @@ because that would be a string comparison. Rather, you need to do a comparison
 like this:
 
 ```xml
-<ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' AND $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), 'v3.0'))">
+<ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' AND $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), '3.0'))">
 ```
 
 And to check for things before a specific version do a comparison like this:
 
 ```xml
-<ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' AND $([MSBuild]::VersionLessThan($(TargetFrameworkVersion), 'v3.0'))">
+<ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' AND $([MSBuild]::VersionLessThan($(TargetFrameworkVersion), '3.0'))">
 ```
 
 If we had used ``TargetFrameworkVersion`` instead of using the ``VersionLessThan`` and the ``VersionGreaterThanOrEquals`` msbuild functions we would see this error for both conditions:

--- a/accepted/2020/net5/net5.md
+++ b/accepted/2020/net5/net5.md
@@ -1024,13 +1024,13 @@ because that would be a string comparison. Rather, you need to do a comparison
 like this:
 
 ```xml
-<ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' AND $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), '3.0'))">
+<ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' AND $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), 'v3.0'))">
 ```
 
 And to check for things before a specific version do a comparison like this:
 
 ```xml
-<ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' AND $([MSBuild]::VersionLessThan($(TargetFrameworkVersion), '3.0'))">
+<ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' AND $([MSBuild]::VersionLessThan($(TargetFrameworkVersion), 'v3.0'))">
 ```
 
 If we had used ``TargetFrameworkVersion`` instead of using the ``VersionLessThan`` and the ``VersionGreaterThanOrEquals`` msbuild functions we would see this error for both conditions:

--- a/accepted/2020/net5/net5.md
+++ b/accepted/2020/net5/net5.md
@@ -1040,9 +1040,10 @@ And to check for things before a specific version do a comparison like this:
 <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' AND '$(_TargetFrameworkVersionWithoutV)' &lt; '3.0'">
 ```
 
-The reason to use the .NET SDK's ``_TargetFrameworkVersionWithoutV`` instead
-of the ``TargetFrameworkVersion`` that is public is because it does not
-prefix the version with a ``v`` making it a string and unable to be compareable.
+If we had used ``TargetFrameworkVersion`` instead of ``_TargetFrameworkVersionWithoutV`` we would see this error for both conditions:
+
+````error MSB4086: A numeric comparison was attempted on "$(TargetFrameworkVersion)" that evaluates to "v3.0" instead of a number, in condition "'$(TargetFrameworkIdentifier)' == '.NETCoreApp' AND '$(_TargetFrameworkVersionWithoutV)' >= '3.0'".````
+``error MSB4086: A numeric comparison was attempted on "$(TargetFrameworkVersion)" that evaluates to "v3.0" instead of a number, in condition "'$(TargetFrameworkIdentifier)' == '.NETCoreApp' AND '$(_TargetFrameworkVersionWithoutV)' &lt; '3.0'".``
 
 By us mapping `net5.0` we break less of that code because existing code will
 treat it correctly (i.e. as a future version of .NET Core) and also avoid

--- a/accepted/2020/net5/net5.md
+++ b/accepted/2020/net5/net5.md
@@ -1030,7 +1030,7 @@ like this:
 And to check for things before a specific version do a comparison like this:
 
 ```xml
-<ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' AND $([MSBuild]::VersionLessThan($(TargetFrameworkVersion), '3.0')">
+<ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' AND $([MSBuild]::VersionLessThan($(TargetFrameworkVersion), '3.0'))">
 ```
 
 If we had used ``TargetFrameworkVersion`` instead of using the ``VersionLessThan`` and the ``VersionGreaterThanOrEquals`` msbuild functions we would see this error for both conditions:

--- a/accepted/2020/net5/net5.md
+++ b/accepted/2020/net5/net5.md
@@ -456,25 +456,26 @@ maintainers some idea of what's available to them.
 
 These are the relevant MSBuild properties:
 
-Property                              | Meaning                         | Examples
---------------------------------------|---------------------------------|---------------------------------
-`TargetFramework` (TFM)               | The friendly name               | `net4`, `netcoreapp3.0`
-`TargetFrameworkIdentifier` (TFI)     | The long name                   | `.NETFramework` or `.NETCoreApp`
-`TargetFrameworkVersion` (TFV)        | The version number              | `2`, `3.0`, `3.1`
-`TargetFrameworkProfile` (TFP)        | The profile                     | `Client` or `Profile124`
-`TargetPlatformIdentifier` (TPI)      | The OS platform                 | `iOS`, `Android`, `Windows`
-`TargetPlatformVersion` (TPV)         | The OS platform version         | `12.0` or `13.0`
-`SupportedOSPlatformVersion` (SOPV)   | The minimum OS platform version | `12.0` or `13.0`
+Property                                  | Meaning                                               | Examples
+------------------------------------------|-------------------------------------------------------|---------------------------------
+`TargetFramework` (TFM)                   | The friendly name                                     | `net4`, `netcoreapp3.0`
+`TargetFrameworkIdentifier` (TFI)         | The long name                                         | `.NETFramework` or `.NETCoreApp`
+`TargetFrameworkVersion` (TFV)            | The version number                                    | `v2`, `v3.0`, `v3.1`
+`_TargetFrameworkVersionWithoutV` (TFVWV) | Same as TFV, but without the v in the resulting value | `2`, `3.0`, `3.1`
+`TargetFrameworkProfile` (TFP)            | The profile                                           | `Client` or `Profile124`
+`TargetPlatformIdentifier` (TPI)          | The OS platform                                       | `iOS`, `Android`, `Windows`
+`TargetPlatformVersion` (TPV)             | The OS platform version                               | `12.0` or `13.0`
+`SupportedOSPlatformVersion` (SOPV)       | The minimum OS platform version                       | `12.0` or `13.0`
 
 We're going to map the TFMs as follows:
 
-TF                 | TFI           | TFV     | TFP | TPI     | TPV | SOPV
--------------------|---------------|---------|-----|---------|-----|----------------
-net4.X             | .NETFramework | 4.X     |     |         |     |
-net5.0             | .NETCoreApp   | 5.0     |     |         |     |
-net5.0-androidX.Y  | .NETCoreApp   | 5.0     |     | Android | X.Y | X.Y (defaulted)
-net5.0-iosX.Y      | .NETCoreApp   | 5.0     |     | iOS     | X.Y | X.Y (defaulted)
-net5.0-windowsX.Y  | .NETCoreApp   | 5.0     |     | Windows | X.Y | X.Y (defaulted)
+TF                 | TFI           | TFV     | TFVWV | TFP | TPI     | TPV | SOPV
+-------------------|---------------|---------|-------|-----|---------|-----|----------------
+net4.X             | .NETFramework | v4.X    |  4.X  |     |         |     |
+net5.0             | .NETCoreApp   | v5.0    |  5.0  |     |         |     |
+net5.0-androidX.Y  | .NETCoreApp   | v5.0    |  5.0  |     | Android | X.Y | X.Y (defaulted)
+net5.0-iosX.Y      | .NETCoreApp   | v5.0    |  5.0  |     | iOS     | X.Y | X.Y (defaulted)
+net5.0-windowsX.Y  | .NETCoreApp   | v5.0    |  5.0  |     | Windows | X.Y | X.Y (defaulted)
 
 Specifically:
 
@@ -492,6 +493,12 @@ Specifically:
 * **SupportedOSPlatformVersion is defaulted to TargetPlatformVersion**. However,
   the customer can override this in the project file to a lower version (using a
   higher version than `TargetPlatformVersion` should generate an error).
+
+ * **_TargetFrameworkVersionWithoutV is normally set only internally in the Microsft.NET.Sdk SDK**.
+   However, the customer might want to use this instead of `TargetFrameworkVersion`
+   because the resulting value is not a string then and is then easily checkable
+   to trap newer or older framework targets to do special stuff with each. This
+   is used in the SDK as well for default implicit framework/packagereferences.
 
 _**Open Issue**. Please note that `net5.0`+ will map the TFI to `.NETCoreApp`.
 We need to announce this change so that package authors with custom .props and
@@ -706,12 +713,12 @@ Framework 1.0), we need to keep it that way. To avoid surprises, we'll by defaul
 use dotted version numbers in project templates to push developers towards being
 explicit.
 
-Framework      | Identifier    | Version| Comment
----------------|---------------|--------|----------------------------------
-net5           | .NETCoreApp   | 5.0    | Will work, but shouldn't be used.
-net5.0         | .NETCoreApp   | 5.0    |
-net10          | .NETFramework | 1.0    |
-net10.0        | .NETCoreApp   | 10.0   |
+Framework      | Identifier    | Version | Comment
+---------------|---------------|---------|----------------------------------
+net5           | .NETCoreApp   | 5.0     | Will work, but shouldn't be used.
+net5.0         | .NETCoreApp   | 5.0     |
+net10          | .NETFramework | 1.0     |
+net10.0        | .NETCoreApp   | 10.0    |
 
 ### Preprocessor Symbols
 
@@ -1020,12 +1027,22 @@ In MSBuild you can't easily do comparisons like:
 <ItemGroup Condition="'$(TargetFramework)' >= 'net5.0'`">
 ```
 
-because that would be a string comparison. Rather, you need to do comparisons
+because that would be a string comparison. Rather, you need to do a comparison
 like this:
 
 ```xml
-<ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' AND '$(TargetFrameworkVersion)' >= '3.0'">
+<ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' AND '$(_TargetFrameworkVersionWithoutV)' >= '3.0'">
 ```
+
+And to check for things before a specific version do a comparison like this:
+
+```xml
+<ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' AND '$(_TargetFrameworkVersionWithoutV)' &lt; '3.0'">
+```
+
+The reason to use the .NET SDK's ``_TargetFrameworkVersionWithoutV`` instead
+of the ``TargetFrameworkVersion`` that is public is because it does not
+prefix the version with a ``v`` making it a string and unable to be compareable.
 
 By us mapping `net5.0` we break less of that code because existing code will
 treat it correctly (i.e. as a future version of .NET Core) and also avoid


### PR DESCRIPTION
The documentation file that I looked at was incorrect at this and when I tried to do the comparison at the bottom I noticed there was errors with it and then looked internally in the SDK and found out it actually prefixes it with an ``v`` and the one I needed was the one without the ``v`` prefix.

As such I felt this document needed some changes and also to note for future viewers what to use if they do not want the prefix from TFV.