### PR TITLE
Followup from adding a design index

### DIFF
--- a/.github/workflows/index.yml
+++ b/.github/workflows/index.yml
@@ -1,0 +1,21 @@
+---
+name: Check INDEX.md is up-to-date
+
+on: [push, pull_request]
+
+jobs:
+  check-index-is-up-to-date:
+    name: Check INDEX.md is up-to-date
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Check INDEX.md is up-to-date
+        shell: bash
+        run: |
+          set -euo pipefail
+          ./update-index > INDEX.md.auto-generated
+          if ! diff -u INDEX.md INDEX.md.auto-generated; then
+            echo "error: INDEX.md is out of date"
+            echo "  please use './update-index > INDEX.md' to regenerate"
+            exit 1
+          fi

--- a/INDEX.md
+++ b/INDEX.md
@@ -38,7 +38,7 @@ Use update-index to regenerate it:
 | 2020 | [.NET Core 3.0 AppDomain Replacement Design and Guidance](accepted/2020/AssemblyLoadContext/AppDomainReplacement.md) | [Steve MacLean](https://github.com/sdmaclea) |
 | 2020 | [.NET Optional SDK Workloads](accepted/2020/workloads/workloads.md) | [Rich Lander](https://github.com/richlander) |
 | 2020 | [.NET Runtime Form Factors](accepted/2020/form-factors.md) | [Rich Lander](https://github.com/richlander), [Jan Kotas](https://github.com/jkotas) |
-| 2020 | [.NET SDK Workload Manifests](accepted/2020/workloads/workload-manifest.md) | [Rich Lander](https://github.com/richlander) |
+| 2020 | [.NET SDK Workload Manifests](accepted/2020/workloads/workload-manifest.md) | [Mikayla Hutchinson](https://github.com/mhutch) |
 | 2020 | [ASN.1 BER/CER/DER Reader & Writer](accepted/2020/asnreader/asnreader.md) | [Jeremy Barton](https://github.com/bartonjs) |
 | 2020 | [Annotating APIs as unsupported on specific platforms](accepted/2020/platform-exclusion/platform-exclusion.md) | [Immo Landwerth](https://github.com/terrajobst) |
 | 2020 | [Annotating platform-specific APIs and detecting its use](accepted/2020/platform-checks/platform-checks.md) | [Immo Landwerth](https://github.com/terrajobst) |
@@ -48,12 +48,12 @@ Use update-index to regenerate it:
 | 2020 | [Easy Acquisition of .NET Framework Targeting Packs](accepted/2020/targeting-packs/targeting-packs.md) | [Immo Landwerth](https://github.com/terrajobst), [Daniel Plaisted](https://github.com/dsplaisted) |
 | 2020 | [Feature switch](accepted/2020/feature-switch.md) | [Vitek Karas](https://github.com/vitek-karas) |
 | 2020 | [Globalization Support in .NET 5](accepted/2020/mono-convergence/globalization-support-in-.net5.md) | [Steve Pfister](https://github.com/steveisok) |
-| 2020 | [Improve Activity API usability and OpenTelemetry integration](accepted/2020/diagnostics/activity-improvements.md) | [Sourabh Shirhatti](https://github.com/shirhatti), [Ankit Srivastava](https://github.com/ankit-oss) [Tarek Mahmoud Sayed](https://github.com/tarekgh) |
+| 2020 | [Improve Activity API usability and OpenTelemetry integration](accepted/2020/diagnostics/activity-improvements.md) | [Sourabh Shirhatti](https://github.com/shirhatti), [Ankit Srivastava](https://github.com/ankit-oss), [Tarek Mahmoud Sayed](https://github.com/tarekgh) |
 | 2020 | [Improve Activity API usability and OpenTelemetry integration (Part 2)](accepted/2020/diagnostics/activity-improvements-2.md) | [Sourabh Shirhatti](https://github.com/shirhatti), [Tarek Mahmoud Sayed](https://github.com/tarekgh) |
 | 2020 | [Install location search for .NET Core](accepted/2020/install-locations.md) | [Vitek Karas](https://github.com/vitek-karas) |
 | 2020 | [JSON extension methods for HttpClient](accepted/2020/json-http-extensions/json-http-extensions.md) | [Immo Landwerth](https://github.com/terrajobst) |
 | 2020 | [Linking the .NET Libraries](accepted/2020/linking-libraries.md) | [Eric Erhardt](https://github.com/eerhardt) |
-| 2020 | [MSBuild SDK Resolvers and optional workloads in .NET 5](accepted/2020/workloads/workload-resolvers.md) | [Rich Lander](https://github.com/richlander) |
+| 2020 | [MSBuild SDK Resolvers and optional workloads in .NET 5](accepted/2020/workloads/workload-resolvers.md) | [Rich Lander](https://github.com/richlander), [Daniel Plaisted](https://github.com/dsplaisted) |
 | 2020 | [Marking APIs that are unsupported by Blazor WebAssembly](accepted/2020/blazor-unsupported-apis/blazor-unsupported-apis.md) | [Immo Landwerth](https://github.com/terrajobst) |
 | 2020 | [Marking Windows-only APIs](accepted/2020/windows-specific-apis/windows-specific-apis.md) | [Immo Landwerth](https://github.com/terrajobst) |
 | 2020 | [OR_GREATER preprocessor symbols for TFMs](accepted/2020/or-greater-defines/or-greater-defines.md) | [Immo Landwerth](https://github.com/terrajobst) |
@@ -82,3 +82,4 @@ Use update-index to regenerate it:
 | [Flexible HTTP APIs](proposed/flexible-http.md) | [Cory Nelson](https://github.com/scalablecory), [Geoff Kizer](https://github.com/geoffkizer) |
 | [Readonly references in C# and IL verification.](proposed/verifiable-ref-readonly.md) |  |
 | [Ref returns in C# and IL verification.](proposed/verifiable-ref-returns.md) |  |
+

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ To create a proposal:
 1. Create a new branch off of `main`
 2. Create a document in the `accepted` folder and use [meta/template.md](meta/template.md) as your
    starting point.
+3. Run `./update-index > INDEX.md` to update the [INDEX](INDEX.md).
 3. Create a pull request against `main`
 4. Once broad agreement is reached, merge the PR
 

--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ To create a proposal:
 2. Create a document in the `accepted` folder and use [meta/template.md](meta/template.md) as your
    starting point.
 3. Run `./update-index > INDEX.md` to update the [INDEX](INDEX.md).
-3. Create a pull request against `main`
-4. Once broad agreement is reached, merge the PR
+4. Create a pull request against `main`
+5. Once broad agreement is reached, merge the PR
 
 ## License
 

--- a/accepted/2020/diagnostics/activity-improvements.md
+++ b/accepted/2020/diagnostics/activity-improvements.md
@@ -2,9 +2,9 @@
 
 [Github issue](https://github.com/dotnet/runtime/issues/31373) has past discussion.
 
-**PM** @shirhatti, anksr
-
-**Dev** @tarekgh
+**PM** [Sourabh Shirhatti](https://github.com/shirhatti) |
+**PM** [Ankit Srivastava](https://github.com/ankit-oss) |
+**Dev** [Tarek Mahmoud Sayed](https://github.com/tarekgh)
 
 .NET has long had [System.Diagnostics.Activity](https://docs.microsoft.com/en-us/dotnet/api/system.diagnostics.activity?view=netcore-3.1) and [System.Diagnostics.DiagnosticListener](https://docs.microsoft.com/en-us/dotnet/api/system.diagnostics.diagnosticlistener?view=netcore-3.1) to support [distributed tracing](https://docs.microsoft.com/en-us/azure/azure-monitor/app/distributed-tracing) scenarios. Code that receives, processes, and transmits requests creates Activity objects which have correlation ids. These Activities are published via DiagnosticListener to telemetry monitoring agents such as Application Insights running in the same process. The telemetry agent can then log the information to a remote store where it can be aggregated and visualized to help developers understand the overall flow of work in a distributed system.
 

--- a/accepted/2020/workloads/workload-manifest.md
+++ b/accepted/2020/workloads/workload-manifest.md
@@ -1,11 +1,6 @@
 # .NET SDK Workload Manifests
 
-**PM** [Rich Lander](https://github.com/richlander)
-
-// FIXME: do these count as PMs/Devs?
-Co-authored-by: Kathleen Dollard
-Co-authored-by: Steve Kirbach
-Co-authored-by: Stephen Toub
+**Dev** [Mikayla Hutchinson](https://github.com/mhutch)
 
 # Overview
 

--- a/accepted/2020/workloads/workload-resolvers.md
+++ b/accepted/2020/workloads/workload-resolvers.md
@@ -1,11 +1,7 @@
 # MSBuild SDK Resolvers and optional workloads in .NET 5
 
 **PM** [Rich Lander](https://github.com/richlander)
-
-// FIXME: do these count as PMs/Devs?
-Co-authored-by: Kathleen Dollard
-Co-authored-by: Steve Kirbach
-Co-authored-by: Stephen Toub
+**Dev** [Daniel Plaisted](https://github.com/dsplaisted)
 
 In .NET 5, we will add support for iOS and Android.  The .NET SDK (formerly known as the .NET Core SDK) will be able to build projects targeting iOS and Android.  However, the .NET SDK will not be a monolithic SDK with support for all possible project types.  Rather, the iOS and Android support (and eventually more pieces) will be delivered as optional SDK workloads which may or may not be installed.  This proposal covers how we will use MSBuild SDK resolvers to hook up the build logic from workloads at build time, and to handle scenarios where a workload required to build a project is not installed.
 

--- a/accepted/2020/workloads/workloads.md
+++ b/accepted/2020/workloads/workloads.md
@@ -2,11 +2,6 @@
 
 **PM** [Rich Lander](https://github.com/richlander)
 
-// FIXME: do these count as PMs/Devs?
-Co-authored-by: Kathleen Dollard
-Co-authored-by: Steve Kirbach
-Co-authored-by: Stephen Toub
-
 In .NET 5.0, we will add support for iOS, Android, and Web assembly projects. Up until .NET 5.0, we’ve delivered all supported workloads via a monolithic SDK. As the supported workloads of the .NET SDK grow (and we want them to), it is no longer tenable to deliver an "all-in-one / one-size-fits-all" SDK distribution. There are many challenges to a large monolithic SDK, with product build time and distribution size being the most significant. Instead, all new workloads will be built and delivered separately from the SDK, and will be acquirable via your favorite installation tool (like the Visual Studio Installer, a Linux package manager, or the .NET CLI). In the fullness of time, we intend for all .NET workloads to follow this pattern, resulting in a very small and focused SDK.
 
 While the monolithic SDK model has become a liability, it was an important design point for .NET Core 2.x and 3.x. This approach enabled us to deliver two key value propositions with the SDK: providing a coherent set of tested workloads (which reduced our test matrix/burden), and enabling offline scenarios (`dotnet new` + `dotnet run` work by default -- for in-box templates -- with no internet). Going forward, it is important to retain those values, even as we move to a fundamentally different SDK composition model.


### PR DESCRIPTION
- CI action to cause a failure if the index is out of date.

  Fix some anomalies in the activity-improvements design that already
  crept in and were causing CI failures.

- Updated steps in the README to add a note about updating the index.

  Thanks for the suggestion, @akoeplinger 

- Fix some leftover FIXME notes in designs.

  I used the file history to guess who the owners were. I decided *not*
  to add commit co-authors to the design index, since those commits read
  like code review rather than designer authorship.

This does not address these two comments:

@danmoseley said:

> do you feel like a follow up change that merges Dev/PM into Owners? If not LMK and I can do it.

I am going to work on this next, but as a separate PR: #194 

@jeffhandley  said:

> @terrajobst Since we recently started adding documents into accepted that are actually in DRAFT status, I wonder if we could also adjust this index to correct the "proposed" vs. "accepted" problem by deemphasizing the folder and instead adding a draft/proposed/accepted/rejected state column to the index. What do you think?

I am going to work on this separately