### PR TITLE
Recognize draft design documents

### DIFF
--- a/INDEX.md
+++ b/INDEX.md
@@ -73,6 +73,13 @@ Use update-index to regenerate it:
 | 2021 | [Compile-time source generation for strongly-typed logging messages](accepted/2021/logging-generator.md) | [Maryam Ariyan](https://github.com/maryamariyan), [Martin Taillefer](https://github.com/geeknoid) |
 | 2021 | [Tracking Platform Dependencies](accepted/2021/platform-dependencies/platform-dependencies.md) | [Matt Thalman](https://github.com/mthalman) |
 
+## Drafts
+
+|Year|Title|Owners|
+|----|-----|------|
+| 2021 | [Improve UTF-8 support](accepted/2021/utf8/README.md) | [Immo Landwerth](https://github.com/terrajobst) |
+| 2021 | [Statics in Interfaces](accepted/2021/statics-in-interfaces/README.md) | [Immo Landwerth](https://github.com/terrajobst), [Mads Torgersen](https://github.com/MadsTorgersen) |
+
 ## Proposals
 
 |Year|Title|Owners|
@@ -80,11 +87,4 @@ Use update-index to regenerate it:
 |  | [Flexible HTTP APIs](proposed/flexible-http.md) | [Cory Nelson](https://github.com/scalablecory), [Geoff Kizer](https://github.com/geoffkizer) |
 |  | [Readonly references in C# and IL verification.](proposed/verifiable-ref-readonly.md) |  |
 |  | [Ref returns in C# and IL verification.](proposed/verifiable-ref-returns.md) |  |
-
-## Drafts
-
-|Year|Title|Owners|
-|----|-----|------|
-| 2021 | [Improve UTF-8 support](accepted/2021/utf8/README.md) | [Immo Landwerth](https://github.com/terrajobst) |
-| 2021 | [Statics in Interfaces](accepted/2021/statics-in-interfaces/README.md) | [Immo Landwerth](https://github.com/terrajobst), [Mads Torgersen](https://github.com/MadsTorgersen) |
 

--- a/INDEX.md
+++ b/INDEX.md
@@ -15,7 +15,7 @@ Use update-index to regenerate it:
 * [Proposal Template](meta/template.md)
 * [Proposals](meta/proposals.md)
 
-## Accepted
+## Accepted Designs
 
 |Year|Title|Owners|
 |----|-----|------|
@@ -71,14 +71,20 @@ Use update-index to regenerate it:
 | 2020 | [Type for holding & converting binary data](accepted/2020/binary-data/binary-data.md) | [Immo Landwerth](https://github.com/terrajobst) |
 | 2021 | [.NET 6.0 Target Frameworks](accepted/2021/net6.0-tfms/net6.0-tfms.md) | [Immo Landwerth](https://github.com/terrajobst) |
 | 2021 | [Compile-time source generation for strongly-typed logging messages](accepted/2021/logging-generator.md) | [Maryam Ariyan](https://github.com/maryamariyan), [Martin Taillefer](https://github.com/geeknoid) |
-| 2021 | [Improve UTF-8 support](accepted/2021/utf8/README.md) | [Immo Landwerth](https://github.com/terrajobst) |
 | 2021 | [Tracking Platform Dependencies](accepted/2021/platform-dependencies/platform-dependencies.md) | [Matt Thalman](https://github.com/mthalman) |
 
-## Proposed
+## Proposals
 
 |Year|Title|Owners|
 |----|-----|------|
 |  | [Flexible HTTP APIs](proposed/flexible-http.md) | [Cory Nelson](https://github.com/scalablecory), [Geoff Kizer](https://github.com/geoffkizer) |
 |  | [Readonly references in C# and IL verification.](proposed/verifiable-ref-readonly.md) |  |
 |  | [Ref returns in C# and IL verification.](proposed/verifiable-ref-returns.md) |  |
+
+## Drafts
+
+|Year|Title|Owners|
+|----|-----|------|
+| 2021 | [Improve UTF-8 support](accepted/2021/utf8/README.md) | [Immo Landwerth](https://github.com/terrajobst) |
+| 2021 | [Statics in Interfaces](accepted/2021/statics-in-interfaces/README.md) | [Immo Landwerth](https://github.com/terrajobst), [Mads Torgersen](https://github.com/MadsTorgersen) |
 

--- a/accepted/2021/statics-in-interfaces/README.md
+++ b/accepted/2021/statics-in-interfaces/README.md
@@ -2,13 +2,12 @@
 
 **DRAFT**
 
-**Libraries PM** [Immo Landwerth](https://github.com/terrajobst)
-**Language PM** [Mads Torgersen](https://github.com/MadsTorgersen)
+**Owners** [Immo Landwerth](https://github.com/terrajobst), [Mads Torgersen](https://github.com/MadsTorgersen)
 
 C# is looking at enabling static abstract members in interfaces (https://github.com/dotnet/csharplang/issues/4436). From the libraries perspective, this is an opportunity to enable "generic math" which could define a new baseline for how developers write algorithms in .NET.
 
-## [Designs](designs/README.md)
+## Designs
 
-## [Requirements](requirements/README.md)
+## Requirements
 
-## [Scenarios](scenarios/README.md)
+## Scenarios

--- a/accepted/2021/statics-in-interfaces/README.md
+++ b/accepted/2021/statics-in-interfaces/README.md
@@ -2,7 +2,7 @@
 
 **DRAFT**
 
-**Owners** [Immo Landwerth](https://github.com/terrajobst), [Mads Torgersen](https://github.com/MadsTorgersen)
+**Owners** [Immo Landwerth](https://github.com/terrajobst) | [Mads Torgersen](https://github.com/MadsTorgersen)
 
 C# is looking at enabling static abstract members in interfaces (https://github.com/dotnet/csharplang/issues/4436). From the libraries perspective, this is an opportunity to enable "generic math" which could define a new baseline for how developers write algorithms in .NET.
 

--- a/accepted/2021/statics-in-interfaces/designs/README.md
+++ b/accepted/2021/statics-in-interfaces/designs/README.md
@@ -1,6 +1,0 @@
-# Designs
-
-**DRAFT**
-
-**Libraries PM** [Immo Landwerth](https://github.com/terrajobst)
-**Language PM** [Mads Torgersen](https://github.com/MadsTorgersen)

--- a/accepted/2021/statics-in-interfaces/requirements/README.md
+++ b/accepted/2021/statics-in-interfaces/requirements/README.md
@@ -1,6 +1,0 @@
-# Requirements
-
-**DRAFT**
-
-**Libraries PM** [Immo Landwerth](https://github.com/terrajobst)
-**Language PM** [Mads Torgersen](https://github.com/MadsTorgersen)

--- a/accepted/2021/statics-in-interfaces/scenarios/README.md
+++ b/accepted/2021/statics-in-interfaces/scenarios/README.md
@@ -1,6 +1,0 @@
-# Scenarios
-
-**DRAFT**
-
-**Libraries PM** [Immo Landwerth](https://github.com/terrajobst)
-**Language PM** [Mads Torgersen](https://github.com/MadsTorgersen)

--- a/tools/update-index/Program.cs
+++ b/tools/update-index/Program.cs
@@ -110,9 +110,9 @@ internal static class Program
         outputWriter.WriteLine();
         WriteDetails(DocumentKind.AcceptedDesign, "Accepted Designs");
         outputWriter.WriteLine();
-        WriteDetails(DocumentKind.ProposedDesign, "Proposals");
-        outputWriter.WriteLine();
         WriteDetails(DocumentKind.DraftDesign, "Drafts");
+        outputWriter.WriteLine();
+        WriteDetails(DocumentKind.ProposedDesign, "Proposals");
         outputWriter.WriteLine();
 
         static string GetMarkdownLink(string relativeTo, string path, string title)
@@ -159,8 +159,8 @@ internal enum DocumentKind
 {
     Meta,
     AcceptedDesign,
-    ProposedDesign,
-    DraftDesign
+    DraftDesign,
+    ProposedDesign
 }
 
 internal sealed class Document

--- a/tools/update-index/Program.cs
+++ b/tools/update-index/Program.cs
@@ -233,7 +233,7 @@ internal sealed class Document
         var reachedSubheading = false;
 
         var titleRegex = new Regex("^# *(?<title>.*?)#?$");
-        var ownerRegex = new Regex(@"^\*\*Owner(s)?\*\*(?<owner>[^|]+)(\s*\|\s*(?<owner>[^|]+))*", RegexOptions.IgnoreCase);
+        var ownerRegex = new Regex(@"^\*\*Owner(s)?\*\*(?<owner>[^|,]+)(\s*[\|,]\s*(?<owner>[^|,]+))*", RegexOptions.IgnoreCase);
         var draftRegex = new Regex(@"^\*\*DRAFT\*\*$", RegexOptions.IgnoreCase);
 
         foreach (var line in lines)

--- a/tools/update-index/Program.cs
+++ b/tools/update-index/Program.cs
@@ -80,7 +80,7 @@ internal static class Program
         catch (Exception ex)
         {
             Console.Error.WriteLine(ex);
-            return 1;                
+            return 1;
         }
     }
 
@@ -103,14 +103,16 @@ internal static class Program
         outputWriter.WriteLine("    ./update-index");
         outputWriter.WriteLine("");
         outputWriter.WriteLine("-->");
-        outputWriter.WriteLine();            
+        outputWriter.WriteLine();
         outputWriter.WriteLine("# Design Index");
-        outputWriter.WriteLine();            
+        outputWriter.WriteLine();
         WriteList(DocumentKind.Meta, "Meta");
         outputWriter.WriteLine();
-        WriteDetails(DocumentKind.AcceptedDesign, "Accepted");
+        WriteDetails(DocumentKind.AcceptedDesign, "Accepted Designs");
         outputWriter.WriteLine();
-        WriteDetails(DocumentKind.ProposedDesign, "Proposed");
+        WriteDetails(DocumentKind.ProposedDesign, "Proposals");
+        outputWriter.WriteLine();
+        WriteDetails(DocumentKind.DraftDesign, "Drafts");
         outputWriter.WriteLine();
 
         static string GetMarkdownLink(string relativeTo, string path, string title)
@@ -157,7 +159,8 @@ internal enum DocumentKind
 {
     Meta,
     AcceptedDesign,
-    ProposedDesign
+    ProposedDesign,
+    DraftDesign
 }
 
 internal sealed class Document
@@ -186,7 +189,7 @@ internal sealed class Document
         }
 
         var directory = fileInfo.Directory;
-        
+
         var kind = (DocumentKind?)null;
         var year = (int?)null;
         var title = (string?)null;
@@ -224,25 +227,41 @@ internal sealed class Document
         }
 
         var lines = File.ReadAllLines(path);
+
+        // Extract titles, owners, and draft status from content above any subheadings
+        var subheadingRegex = new Regex("^#{2,}");
+        var reachedSubheading = false;
+
         var titleRegex = new Regex("^# *(?<title>.*?)#?$");
-        var ownerRegex = new Regex(@"^\*\*Owner\*\*(?<owner>[^|]+)(\s*\|\s*(?<owner>[^|]+))*");
+        var ownerRegex = new Regex(@"^\*\*Owner(s)?\*\*(?<owner>[^|]+)(\s*\|\s*(?<owner>[^|]+))*", RegexOptions.IgnoreCase);
+        var draftRegex = new Regex(@"^\*\*DRAFT\*\*$", RegexOptions.IgnoreCase);
 
         foreach (var line in lines)
         {
-            var titleMatch = titleRegex.Match(line);
-            var ownerMatch = ownerRegex.Match(line);
+            reachedSubheading = reachedSubheading || subheadingRegex.Match(line).Success;
 
-            if (titleMatch.Success && title == null)
+            if (!reachedSubheading)
             {
-                title = titleMatch.Groups["title"].Value.Trim();
-            }
-            else if (ownerMatch.Success)
-            {
-                foreach (Capture capture in ownerMatch.Groups["owner"].Captures)
+                var titleMatch = titleRegex.Match(line);
+                var ownerMatch = ownerRegex.Match(line);
+                var draftMatch = draftRegex.Match(line);
+
+                if (titleMatch.Success && title == null)
                 {
-                    var owner =capture.Value.Trim();
-                    if (owner.Length > 0)
-                        owners.Add(owner);
+                    title = titleMatch.Groups["title"].Value.Trim();
+                }
+                else if (ownerMatch.Success)
+                {
+                    foreach (Capture capture in ownerMatch.Groups["owner"].Captures)
+                    {
+                        var owner =capture.Value.Trim();
+                        if (owner.Length > 0)
+                            owners.Add(owner);
+                    }
+                }
+                else if (draftMatch.Success)
+                {
+                    kind = DocumentKind.DraftDesign;
                 }
             }
         }

--- a/tools/update-index/Program.cs
+++ b/tools/update-index/Program.cs
@@ -254,7 +254,7 @@ internal sealed class Document
                 {
                     foreach (Capture capture in ownerMatch.Groups["owner"].Captures)
                     {
-                        var owner =capture.Value.Trim();
+                        var owner = capture.Value.Trim();
                         if (owner.Length > 0)
                             owners.Add(owner);
                     }


### PR DESCRIPTION
Since we're starting to move away from the `proposed` folder and instead mark designs as **DRAFT**, this PR recognizes the `**DRAFT**` marker in design documents and introduces a "Drafts" section to the index. This change also:

* Allows either `"**Owner**"` or `"**Owners**"` to be recognized
* Recognizes comma-separated lists of owners (in addition to pipe-separated lists)
* Limits recognition of Title, Owner, and Draft to content above the first subheading (avoiding false positive matches within document contents)
* Flattens the structure of the statics-in-interfaces draft per feedback on #186 (FYI @tannergooding)