### PR TITLE
Include net6.0-android in precendence rules

### DIFF
--- a/accepted/2021/net6.0-tfms/net6.0-tfms.md
+++ b/accepted/2021/net6.0-tfms/net6.0-tfms.md
@@ -160,7 +160,7 @@ This reasoning results in these precedence rules:
 1. `net5.0`
 1. `netcoreapp3.1` – `1.0`
 1. `netstandard2.1` – `1.0`
-1. `net4.x` – `1.0` (warning)
+1. `net4.x` – `1.0` ([NU1701] warning)
 
 The currently supported `monoandroid` TFMs are:
 

--- a/accepted/2021/net6.0-tfms/net6.0-tfms.md
+++ b/accepted/2021/net6.0-tfms/net6.0-tfms.md
@@ -51,7 +51,7 @@ app.
 |--------------------|------------------------------------------|
 | net6.0             | (subsequent version of net5.0)           |
 | net6.0-windows     | (subsequent version of net5.0-windows)   |
-| net6.0-android     | xamarin.android                          |
+| net6.0-android     | monoandroid                              |
 |                    | (+everything else inherited from net6.0) |
 | net6.0-ios         | xamarin.ios                              |
 |                    | (+everything else inherited from net6.0) |
@@ -107,7 +107,10 @@ follows:
       use `net6.0` or multi-target for `net6.0-ios` and `net6.0-maccatalyst`
 
 We want the same rules for `net6.0-ios` except that using `xamarin.ios` should
-not generate a warning. This reasoning results in these precedence rules:
+not generate a warning. `net6.0-android` will behave in the same way as `net6.0-ios`,
+except that the Xamarin.Android TFM is `monoandroid` (1.0 - 12.0).
+
+This reasoning results in these precedence rules:
 
 **net6.0-ios**
 
@@ -148,6 +151,33 @@ not generate a warning. This reasoning results in these precedence rules:
 1. `netcoreapp3.1` – `1.0`
 1. `netstandard2.1` – `1.0`
 1. `net4.x` – `1.0` ([NU1701] warning)
+
+**net6.0-android**
+
+1. `net6.0-android`
+1. `net6.0`
+1. `monoandroid12.0` - `1.0` (no warning)
+1. `net5.0`
+1. `netcoreapp3.1` – `1.0`
+1. `netstandard2.1` – `1.0`
+1. `net4.x` – `1.0` (warning)
+
+The currently supported `monoandroid` TFMs are:
+
+* `monoandroid1.0`
+* `monoandroid4.4`
+* `monoandroid4.4.87`
+* `monoandroid5.0`
+* `monoandroid5.1`
+* `monoandroid6.0`
+* `monoandroid7.0`
+* `monoandroid7.1`
+* `monoandroid8.0`
+* `monoandroid8.1`
+* `monoandroid9.0`
+* `monoandroid10.0`
+* `monoandroid11.0`
+* `monoandroid12.0`
 
 ## APIs
 


### PR DESCRIPTION
Context: https://github.com/NuGet/NuGet.Client/pull/4011#issuecomment-825898873

The `Compatibility rules` section in `net6.0-tfms.md` didn't list the
precedence rules for `net6.0-android`.

These should be the same as `net6.0-ios`, except that instead of
`xamarin.ios`, we have:

* `monoandroid1.0`
* `monoandroid4.4`
* `monoandroid4.4.87`
* `monoandroid5.0`
* `monoandroid5.1`
* `monoandroid6.0`
* `monoandroid7.0`
* `monoandroid7.1`
* `monoandroid8.0`
* `monoandroid8.1`
* `monoandroid9.0`
* `monoandroid10.0`
* `monoandroid11.0`
* `monoandroid12.0`

This can be illustrated somewhat by the `$(PackageTargetFallback)`
workaround the Android workload is using in the current .NET 6
previews:

https://github.com/xamarin/xamarin-android/blob/e59f6493fedd789cbd3157d369104516cfffd3f0/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.NuGet.targets#L19-L35

We should be able to completely remove the
`Microsoft.Android.Sdk.NuGet.targets` file, when full NuGet support is
added.