### PR TITLE
Add special case for Xamarin assets to nuget precedence rules

### DIFF
--- a/accepted/2021/net6.0-tfms/net6.0-tfms.md
+++ b/accepted/2021/net6.0-tfms/net6.0-tfms.md
@@ -99,6 +99,9 @@ follows:
     - However, it should still prefer `net6.0` assets over `xamarin.ios`.
     - It also shouldn't be compatible with any other existing Xamarin TFM (such
       as `xamarin.mac`)
+* It should prefer `netstandard2.1` and earlier assets before `net5.0`
+    - Packages with `net5.0`, `netcoreapp3.1` and earlier assets assumed desktop-like environments,
+      since this was the only place where .NET Core existed. This causes issues on mobile.
 * Generate NuGet warning [NU1701] when a `xamarin.ios` asset is being used
     - Package 'packageId' was restored using 'xamarin.ios' instead the project
       target framework 'net6.0-maccatalyst'. This package may not be fully
@@ -128,9 +131,9 @@ This reasoning results in these precedence rules:
 1. `net6.0-ios`
 1. `net6.0`
 1. `xamarin.ios` (no warning, skip if it points to `_._`)
+1. `netstandard2.1` – `1.0`
 1. `net5.0`
 1. `netcoreapp3.1` – `1.0`
-1. `netstandard2.1` – `1.0`
 1. `net4.x` – `1.0` (warning)
 
 **net6.0-maccatalyst**
@@ -138,9 +141,9 @@ This reasoning results in these precedence rules:
 1. `net6.0-maccatalyst`
 1. `net6.0`
 1. `xamarin.ios` ([NU1701] warning, skip if it points to `_._`)
+1. `netstandard2.1` – `1.0`
 1. `net5.0`
 1. `netcoreapp3.1` – `1.0`
-1. `netstandard2.1` – `1.0`
 1. `net4.x` – `1.0 ([NU1701] warning)
 
 **net6.0-macos**
@@ -148,9 +151,9 @@ This reasoning results in these precedence rules:
 1. `net6.0-macos`
 1. `net6.0`
 1. `xamarin.macos` (no warning, skip if it points to `_._`)
+1. `netstandard2.1` – `1.0`
 1. `net5.0`
 1. `netcoreapp3.1` – `1.0`
-1. `netstandard2.1` – `1.0`
 1. `net4.x` – `1.0` ([NU1701] warning)
 
 **net6.0-tvos**
@@ -158,9 +161,9 @@ This reasoning results in these precedence rules:
 1. `net6.0-tvos`
 1. `net6.0`
 1. `xamarin.tvos` (no warning, skip if it points to `_._`)
+1. `netstandard2.1` – `1.0`
 1. `net5.0`
 1. `netcoreapp3.1` – `1.0`
-1. `netstandard2.1` – `1.0`
 1. `net4.x` – `1.0` ([NU1701] warning)
 
 **net6.0-android**
@@ -168,9 +171,9 @@ This reasoning results in these precedence rules:
 1. `net6.0-android`
 1. `net6.0`
 1. `monoandroid12.0` - `1.0` (no warning, skip if it points to `_._`)
+1. `netstandard2.1` – `1.0`
 1. `net5.0`
 1. `netcoreapp3.1` – `1.0`
-1. `netstandard2.1` – `1.0`
 1. `net4.x` – `1.0` ([NU1701] warning)
 
 The currently supported `monoandroid` TFMs are:

--- a/accepted/2021/net6.0-tfms/net6.0-tfms.md
+++ b/accepted/2021/net6.0-tfms/net6.0-tfms.md
@@ -114,13 +114,20 @@ not generate a warning. `net6.0-android` will behave in the same way as `net6.0-
 except that the Xamarin.Android TFM is `monoandroid` (1.0 - 12.0). `net6.0-tizen` is
 also the same as `net6.0-ios` except the TFM is `tizen`.
 
+A special case are packages which have a Xamarin TFM asset that points to `_._` which normally
+means that the asset should be picked from the framework/GAC instead of the package.
+However we have cases like `System.ComponentModel.Composition` where in "legacy" Xamarin this
+assembly shipped as part of the framework (hence e.g. `xamarin.ios` in the package points to `_._`)
+but in .NET Core the assembly is _not_ in the shared framework. We need to skip picking the
+Xamarin TFM asset in this case to avoid a build break due to missing references.
+
 This reasoning results in these precedence rules:
 
 **net6.0-ios**
 
 1. `net6.0-ios`
 1. `net6.0`
-1. `xamarin.ios` (no warning)
+1. `xamarin.ios` (no warning, skip if it points to `_._`)
 1. `net5.0`
 1. `netcoreapp3.1` – `1.0`
 1. `netstandard2.1` – `1.0`
@@ -130,7 +137,7 @@ This reasoning results in these precedence rules:
 
 1. `net6.0-maccatalyst`
 1. `net6.0`
-1. `xamarin.ios` ([NU1701] warning)
+1. `xamarin.ios` ([NU1701] warning, skip if it points to `_._`)
 1. `net5.0`
 1. `netcoreapp3.1` – `1.0`
 1. `netstandard2.1` – `1.0`
@@ -140,7 +147,7 @@ This reasoning results in these precedence rules:
 
 1. `net6.0-macos`
 1. `net6.0`
-1. `xamarin.macos` (no warning)
+1. `xamarin.macos` (no warning, skip if it points to `_._`)
 1. `net5.0`
 1. `netcoreapp3.1` – `1.0`
 1. `netstandard2.1` – `1.0`
@@ -150,7 +157,7 @@ This reasoning results in these precedence rules:
 
 1. `net6.0-tvos`
 1. `net6.0`
-1. `xamarin.tvos` (no warning)
+1. `xamarin.tvos` (no warning, skip if it points to `_._`)
 1. `net5.0`
 1. `netcoreapp3.1` – `1.0`
 1. `netstandard2.1` – `1.0`
@@ -160,7 +167,7 @@ This reasoning results in these precedence rules:
 
 1. `net6.0-android`
 1. `net6.0`
-1. `monoandroid12.0` - `1.0` (no warning)
+1. `monoandroid12.0` - `1.0` (no warning, skip if it points to `_._`)
 1. `net5.0`
 1. `netcoreapp3.1` – `1.0`
 1. `netstandard2.1` – `1.0`


### PR DESCRIPTION
While working on .NET 6 support for Xamarin we hit a build break in a test project when referencing the System.ComponentModel.Composition v4.7.0 nuget package.

```
xamarin-macios/tests/linker/ios/link all/MEFTests.cs(3,29): error CS0234: The type or namespace name 'Composition' does not exist in the namespace 'System.ComponentModel' (are you missing an assembly reference?)
```
 
We've tracked it down to the nuget restore storing this in obj/project.assets.json:
 
```
      "System.ComponentModel.Composition/4.7.0": {
        "type": "package",
        "compile": {
          "ref/xamarinios10/_._": {}
        },
        "runtime": {
          "lib/xamarinios10/_._": {}
        }
      },
```

I.e. it wants to pick the assembly from the GAC/framework, which is what we want for the legacy Xamarin (since System.ComponentModel.Composition shipped in the framework there) but _not_ for the new .NET6-based one since it is an out-of-band package there and doesn't ship in the framework.

We're proposing an addition to the nuget precedence rules to skip the Xamarin TFM asset in this case, so we fallback to the netcoreapp2.0 assembly.

The other alternative would be to add an explicit `net6.0` asset to the package, however this would only apply to new releases since we can't fix the existing nugets.

**Note:** we discovered additional issues while working on this, see https://github.com/dotnet/designs/pull/222#issuecomment-852178771 so we're also proposing to change the precedence rules to prefer `netstandard` assets before `net5.0`

/cc @marek-safar @ericstj @rolfbjarne
