### PR TITLE
Experimental APIs

### DIFF
--- a/INDEX.md
+++ b/INDEX.md
@@ -81,7 +81,7 @@ Use update-index to regenerate it:
 | 2021 | [TFM for .NET nanoFramework](accepted/2021/nano-framework-tfm/nano-framework-tfm.md) | [Immo Landwerth](https://github.com/terrajobst), [Laurent Ellerbach](https://github.com/Ellerbach), [José Simões](https://github.com/josesimoes) |
 | 2021 | [Tracking Platform Dependencies](accepted/2021/platform-dependencies/platform-dependencies.md) | [Matt Thalman](https://github.com/mthalman) |
 | 2022 | [.NET 7 Version Selection Improvements](accepted/2022/version-selection.md) | [Rich Lander](https://github.com/richlander) |
-| 2023 | [Library Preview Features](accepted/2023/preview-apis/preview-apis.md) | [Immo Landwerth](https://github.com/terrjobst) |
+| 2023 | [Experimental APIs](accepted/2023/preview-apis/preview-apis.md) | [Immo Landwerth](https://github.com/terrjobst) |
 
 ## Drafts
 

--- a/INDEX.md
+++ b/INDEX.md
@@ -81,6 +81,7 @@ Use update-index to regenerate it:
 | 2021 | [TFM for .NET nanoFramework](accepted/2021/nano-framework-tfm/nano-framework-tfm.md) | [Immo Landwerth](https://github.com/terrajobst), [Laurent Ellerbach](https://github.com/Ellerbach), [José Simões](https://github.com/josesimoes) |
 | 2021 | [Tracking Platform Dependencies](accepted/2021/platform-dependencies/platform-dependencies.md) | [Matt Thalman](https://github.com/mthalman) |
 | 2022 | [.NET 7 Version Selection Improvements](accepted/2022/version-selection.md) | [Rich Lander](https://github.com/richlander) |
+| 2023 | [Library Preview Features](accepted/2023/preview-apis/preview-apis.md) | [Immo Landwerth](https://github.com/terrjobst) |
 
 ## Drafts
 

--- a/accepted/2023/preview-apis/preview-apis.md
+++ b/accepted/2023/preview-apis/preview-apis.md
@@ -189,6 +189,6 @@ them makes it easier to communicate that difference to our users.
 ### Why is this not an analyzer?
 
 The compiler team suggested to make this a compiler behavior, rather than an
-analyzer. This would allow the attribute to have a `DiagnosticId` which regular
-analyzers can't (because a given analyzer has to tell the compiler upfront which
-diagnostic IDs it will raise).
+analyzer. This would allow the attribute to specify custom `DiagnosticId` values
+which regular analyzers can't (because a given analyzer has to tell the compiler
+upfront which diagnostic IDs it will raise).

--- a/accepted/2023/preview-apis/preview-apis.md
+++ b/accepted/2023/preview-apis/preview-apis.md
@@ -1,0 +1,196 @@
+# Library Preview Features
+
+**Owner** [Immo Landwerth](https://github.com/terrjobst)
+
+In .NET 6, we've added a way to [ship preview features][preview-features] in
+otherwise stable releases. It works by tagging APIs (and language features) as
+preview features and requiring the user's project to explicitly opt-into using
+them via the `<EnablePreviewFeatures>` property.
+
+The feature was primarily designed to accommodate platform-level features, that
+is for features that span runtime, library, and language, such as generic math.
+However, we also believed that the feature would work for libraries that want to
+offer preview functionality in otherwise stable NuGet packages.
+
+Since then, we've seen requests from partners who have tried using it and hit
+limitations that come from guardrails we put into place due to the complex
+nature of platform-level preview features.
+
+The goal of this feature is to find a design that works for both, platform-level
+preview features and library-level preview features.
+
+Let's first define these two terms:
+
+* **platform-level preview feature**. These are features that rely on preview
+ behaviors across runtime, core library, tooling, and languages. The nature of
+ these features that they are in support of each other. For example, generic
+ math requires new runtime behaviors for interfaces, which the language has to
+ support, and of course new interfaces and methods in core library that
+ leverages them. If you want to use generic math, you need a combination of
+ runtime, framework, and language that were designed to work in conjunction.
+
+* **library-level preview feature**. These are library APIs that don't require
+  any platform-level preview features to be consumed. The only difference to
+  regular APIs is that these are in preview so their shape isn't stable and thus
+  offers no backwards compatibility when upgrading to a later version of the
+  library.
+
+Due to their nature, platform-level preview features can only be consumed in
+specific combination of framework and SDK: namely, the framework and SDK version
+must match. For example, you can only use preview features in `net6.0` when
+using the .NET 6 SDK and only use preview features in `net7.0` when using the
+.NET 7 SDK. Specifically, you can't use the .NET 7 SDK to use preview features
+in `net6.0`. That's because preview features aren't backwards compatible and
+platform-level preview features span both framework and tooling. In
+multi-targeting scenarios this means you can only use preview features for the
+latest framework version.
+
+For platform-level preview features this restriction makes sense because it
+models reality. However, for library-level preview features not only does this
+restriction not make sense, it's highly undesirable. Library authors simply want
+a way to express "these parts of my API surface might change". This statement
+isn't tied to any runtime-, framework-, or language features.
+
+## Scenarios and User Experience
+
+## Requirements
+
+### Goals
+
+* Platform-level preview features need the same guardrails as before, specifically
+    - They require opt-in (without, the build fails with an error)
+    - They require to be viral (i.e. opt-in is also required for indirect
+      dependencies relying on preview features)
+    - They require SDK and framework to match
+* Library-level preview need to have same guard rails, except for the
+  requirement of SDK and framework to match
+
+### Non-Goals
+
+* Extending this feature to allow for multiple independent preview features
+
+## Stakeholders and Reviewers
+
+* Runtime teams
+* C#, VB, F# compiler and IDE teams
+* Library teams
+    - Core libraries
+    - ASP.NET
+    - EF
+    - Azure SDK
+    - R9
+* Project system team
+* SDK team
+* MSBuild team
+* NuGet team
+
+## Design
+
+### Project file
+
+We change the behavior of `EnablePreviewFeatures` to allow four values instead
+of the current `bool`:
+
+| Value                | Meaning                                                                                  |
+| -------------------- | ---------------------------------------------------------------------------------------- |
+| `False`              | Off. Neither platform- nor library-level preview features can be consumed.               |
+| `True`               | Same as `LibraryAndPlatform`                                                             |
+| `Library`            | You can consume library-level preview features, but not platform-level preview features. |
+| `LibraryAndPlatform` | You can consume both library- and platform-level preview features.                       |
+
+```xml
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <EnablePreviewFeatures>LibraryAndPlatform</EnablePreviewFeatures>
+  </PropertyGroup>
+
+</Project>
+```
+
+### SDK
+
+Currently, the SDK ignores `<EnablePreviewFeatures>` unless the target framework
+is the SDK's current version. This will change the behavior as follows:
+
+If `<EnablePreviewFeatures>` is set to `LibraryAndPlatform` and the target
+framework isn't the current version, it will be interpreted is if it was set to
+`Library`.
+
+### Attribute
+
+We'll extend the `[RequiresPreviewFeatures]` to take in the scope. The existing
+constructors will behave as if the scope is `PreviewScope.LibraryAndPlatform`:
+
+```C#
+namespace System.Runtime.Versioning;
+
+public enum PreviewScope
+{
+    LibraryAndPlatform,
+    Library
+}
+
+[AttributeUsage(AttributeTargets.Assembly |
+                AttributeTargets.Module |
+                AttributeTargets.Class |
+                AttributeTargets.Struct |
+                AttributeTargets.Enum |
+                AttributeTargets.Constructor |
+                AttributeTargets.Method |
+                AttributeTargets.Property |
+                AttributeTargets.Field |
+                AttributeTargets.Event |
+                AttributeTargets.Interface |
+                AttributeTargets.Delegate, Inherited = false)]
+public sealed class RequiresPreviewFeaturesAttribute : Attribute
+{
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public RequiresPreviewFeaturesAttribute() {}
+        : this(PreviewScope.LibraryAndPlatform, message) {}
+
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public RequiresPreviewFeaturesAttribute(string? message)
+        : this(PreviewScope.LibraryAndPlatform, message) {}
+
+    // NEW
+    public RequiresPreviewFeaturesAttribute(PreviewScope scope) {}
+
+    // NEW
+    public RequiresPreviewFeaturesAttribute(PreviewScope scope, string? message) {}
+
+    // NEW
+    public PreviewScope scope { get; }
+
+    public string? Message { get; }
+    public string? Url { get; set; }
+}
+```
+
+### Analyzer
+
+The analyzer will be changed as follows:
+
+* APIs marked with `PreviewScope.LibraryAndPlatform` can only be used if the
+ consumer is also marked with `PreviewScope.LibraryAndPlatform`.
+
+* APIs marked with `PreviewScope.Library` can only be used if the consumer is
+  marked with either `PreviewScope.LibraryAndPlatform` or
+  `PreviewScope.Library`.
+
+We should add a new diagnostic ID when library-level preview APIs are being used
+without opt-in (i.e. the second case above).
+
+## Tracking Items
+
+* The overall work of enabling this feature for libraries
+    - [dotnet/runtime#77869](https://github.com/dotnet/runtime/issues/77869)
+* Shipping `RequiresPreviewFeaturesAttribute` for downlevel
+    - [dotnet/runtime#79479](https://github.com/dotnet/runtime/issues/79479)
+* Highlighting preview APIs in docs
+    - [dotnet/dotnet-api-docs#6861](https://github.com/dotnet/dotnet-api-docs/issues/6861)
+* Highlighting preview APIs in IDE
+    - [dotnet/roslyn#65915](https://github.com/dotnet/roslyn/issues/65915)
+
+[preview-features]: ../../2021/preview-features/preview-features.md

--- a/accepted/2023/preview-apis/preview-apis.md
+++ b/accepted/2023/preview-apis/preview-apis.md
@@ -228,6 +228,12 @@ project-wide `NoWarn`).
     - [dotnet/dotnet-api-docs#6861](https://github.com/dotnet/dotnet-api-docs/issues/6861)
 * Highlighting preview APIs in IDE
     - [dotnet/roslyn#65915](https://github.com/dotnet/roslyn/issues/65915)
+* Consider highlight preview APIs when APIs represent UI elements that aren't
+  used via user written code
+    - Areas to consider:
+    - Toolbox
+    - Property Grid
+    - Design Service
 
 [preview-features]: ../../2021/preview-features/preview-features.md
 

--- a/accepted/2023/preview-apis/preview-apis.md
+++ b/accepted/2023/preview-apis/preview-apis.md
@@ -148,7 +148,7 @@ public sealed class RequiresPreviewFeaturesAttribute : Attribute
 {
     [EditorBrowsable(EditorBrowsableState.Never)]
     public RequiresPreviewFeaturesAttribute() {}
-        : this(PreviewScope.LibraryAndPlatform, message) {}
+        : this(PreviewScope.LibraryAndPlatform) {}
 
     [EditorBrowsable(EditorBrowsableState.Never)]
     public RequiresPreviewFeaturesAttribute(string? message)

--- a/accepted/2023/preview-apis/preview-apis.md
+++ b/accepted/2023/preview-apis/preview-apis.md
@@ -1,4 +1,4 @@
-# Library Preview Features
+# Experimental APIs
 
 **Owner** [Immo Landwerth](https://github.com/terrjobst)
 
@@ -64,6 +64,9 @@ Since library-level preview features cannot change how the .NET runtime itself
 operates, we don't have that same level of concern. In fact, we believe the
 viral nature is also undesirable.
 
+For the remainder of this proposal we'll refer to *library-level preview*
+features as *experimental APIs*.
+
 ## Scenarios and User Experience
 
 ## Requirements
@@ -123,9 +126,9 @@ namespace System.Diagnostics.CodeAnalysis;
                 AttributeTargets.Event |
                 AttributeTargets.Interface |
                 AttributeTargets.Delegate, Inherited = false)]
-public sealed class PreviewAttribute : Attribute
+public sealed class ExperimentalAttribute : Attribute
 {
-    public PreviewAttribute(string diagnosticId);
+    public ExperimentalAttribute(string diagnosticId);
     public string DiagnosticId { get; }
     public string? UrlFormat { get; set; }
 }
@@ -133,15 +136,15 @@ public sealed class PreviewAttribute : Attribute
 
 ### Compiler Behavior
 
-The compiler will raise a diagnostic when a preview API is used, using supplied
-diagnostic ID. The severity is always error.
+The compiler will raise a diagnostic when an experimental API is used, using the
+supplied diagnostic ID. The severity is always error.
 
 The semantics are identical to how obsolete is tracked, except that it will
 always raise a diagnostic regardless of whether the call site is marked as
-preview or not. There is also no special treatment when both caller and callee
-are in the same assembly -- any use will generate a diagnostic and the caller is
-expected to suppress it, with the usual means (i.e. `#pragma` or project-wide
-`NoWarn`).
+experimental or not. There is also no special treatment when both caller and
+callee are in the same assembly -- any use will generate a diagnostic and the
+caller is expected to suppress it, with the usual means (i.e. `#pragma` or
+project-wide `NoWarn`).
 
 ## Tracking Items
 
@@ -185,6 +188,18 @@ We considered offering a different mode for `RequiresPreviewFeaturesAttribute`
 instead of using a different attribute but we believe this makes it harder to
 understand as these are really disjoint features. Having different names for
 them makes it easier to communicate that difference to our users.
+
+### Why did we use the term `Experimental` over `Preview`?
+
+This change was based on [this discussion][experimental-discussion]:
+
+1. It more strongly separates the existing `RequiresPreviewFeatures` from this
+   new feature.
+
+2. Folks found it it better aligns with the naming of the community and other
+   parts of our stack that has the same semantics (such as WinRT).
+
+[experimental-discussion]: https://github.com/dotnet/designs/pull/285#discussion_r1082052754
 
 ### Why is this not an analyzer?
 

--- a/accepted/2023/preview-apis/preview-apis.md
+++ b/accepted/2023/preview-apis/preview-apis.md
@@ -234,6 +234,10 @@ project-wide `NoWarn`).
     - Toolbox
     - Property Grid
     - Design Service
+* Consider providing an analyzer that warns when
+  `RequiresPreviewFeaturesAttribute` is being used in (user written) code.
+    - It should only be used by the platform
+    - We should point users to this new attribute (`ExperimentalAttribute`)
 
 [preview-features]: ../../2021/preview-features/preview-features.md
 

--- a/accepted/2023/preview-apis/preview-apis.md
+++ b/accepted/2023/preview-apis/preview-apis.md
@@ -170,6 +170,8 @@ stops exploring that API.
     - EF
     - Azure SDK
     - R9
+    - Windows Forms
+    - WPF
 * Project system team
 * SDK team
 * MSBuild team

--- a/accepted/2023/preview-apis/preview-apis.md
+++ b/accepted/2023/preview-apis/preview-apis.md
@@ -69,6 +69,76 @@ features as *experimental APIs*.
 
 ## Scenarios and User Experience
 
+### Shipping an experimental API in a stable package
+
+Martin builds a library that integrates with ASP.NET Core and provides features
+to make it easier to build services. The library is distributed as a NuGet
+package. The package is already in a version well past 1.0 and is considered
+stable.
+
+He ships the package often and doesn't want to maintain multiple flavors of the
+package, one marked as prerelease and one marked as stable. However, he wants to
+expose new APIs without making the promise that these APIs are stable. He
+designs the new APIs as if they would be stable, that is, he puts them in the
+namespace they belong and names the types and members without any naming
+convention that implies that they aren't stable yet. If customer feedback is
+positive, the API will become stable as-is, otherwise he'll make changes to
+address the feedback.
+
+In order to convey to the consumers that these APIs aren't stable yet, he puts
+the `Experimental` attribute on them:
+
+```C#
+namespace MartinsLibrary.FancyLogging
+{
+    public static class FancyLoggerExtensions
+    {
+        [Experimental("ML123", UrlFormat="https://martinslibrary.net/diagnostics/{0}")]
+        public static IServiceCollection AddFancyLogging(this IServiceCollections services)
+        {
+            // ...
+        }
+    }
+}
+```
+
+### Consuming an experimental API
+
+David builds a new version of Jabber.NET and consumes Martin's library. He very
+much wants to play with the new fancy logging Martin added. When David calls
+`AddFancyLogging` he gets a compilation error:
+
+> error ML123: FancyLoggerExtensions.AddFancyLogging() is not a stable API. In
+  order to consume this experimental API, suppress this error from the call
+  site.
+
+David is happy to accommodate future breaking changes around the fancy logging
+feature. He understands that the diagnostic ID is specific to the fancy logging
+feature of Martin's library, so he decides to add a suppression to the project
+file:
+
+```xml
+<Project>
+    <PropertyGroup>
+        <!-- Fancy logging is an experimental APIs -->
+        <NoWarn>$(NoWarn);ML123</NoWarn>
+    </PropertyGroup>
+</Project>
+```
+
+### Consuming another experimental API
+
+Later, David discovers Martin's library also has support for fancy serialization.
+When he starts consuming it, he gets another compilation error:
+
+> error ML456: FancySerializationExtensions.AddFancySerialization() is not a
+  stable API. In order to consume this experimental API, suppress this error
+  from the call site.
+
+Giving it some thought, David concludes that the risk of using an unstable
+serialization API isn't worth it because it's not necessary for Jabber, so he
+stops exploring that API.
+
 ## Requirements
 
 ### Goals

--- a/accepted/2023/preview-apis/preview-apis.md
+++ b/accepted/2023/preview-apis/preview-apis.md
@@ -228,7 +228,7 @@ project-wide `NoWarn`).
     - [dotnet/dotnet-api-docs#6861](https://github.com/dotnet/dotnet-api-docs/issues/6861)
 * Highlighting preview APIs in IDE
     - [dotnet/roslyn#65915](https://github.com/dotnet/roslyn/issues/65915)
-* Consider highlight preview APIs when APIs represent UI elements that aren't
+* Consider highlighting preview APIs when APIs represent UI elements that aren't
   used via user written code
     - Areas to consider:
     - Toolbox


### PR DESCRIPTION
In .NET 6, we've added a way to [ship preview features](https://github.com/dotnet/designs/blob/main/accepted/2021/preview-features/preview-features.md) in otherwise stable releases. It works by tagging APIs (and language features) as preview features and requiring the user's project to explicitly opt-into using them via the `<EnablePreviewFeatures>` property.

The feature was primarily designed to accommodate platform-level features, that is for features that span runtime, library, and language, such as generic math. However, we also believed that the feature would work for libraries that want to offer preview functionality in otherwise stable NuGet packages.

Since then, we've seen requests from partners who have tried using it and hit limitations that come from guardrails we put into place due to the complex nature of platform-level preview features.

The goal of this feature is to find a design that works for both, platform-level preview features and library-level preview features.