### PR TITLE
Adding in folder for Tensor<T> info

### DIFF
--- a/proposed/tensor/type-and-memory-comparison.md
+++ b/proposed/tensor/type-and-memory-comparison.md
@@ -1,0 +1,52 @@
+
+| | libTorch | ONNX | Numpy | TensorFlow | Julia |
+| --- | --- | --- | --- | --- | --- |
+| **Types Supported** | | | | | |
+|  |  |  |  |  |
+| byte | X | X | | X | X | X |
+| sbyte | X | X | X | X | X |
+| ushort | X | X | X | X | X |
+| short | X | X | X | X | X |
+| int | X | X | X | X | X |
+| uint | X | X | X | X | X |
+| long | X | X | X | X | X |
+| ulong | X | X | X | X | X |
+| bool (byte) | X | X | X | X | X |
+| string (bytes) |  | X | X | X
+| string (unicode) |  |  | X | 
+| string (c++ std::string) |  | X |  | 
+| float | X | X | X | X | X |
+| float16 | X | X | X | X | X |
+| bfloat16 | X | X |  | X |
+| double | X | X | X | X | X |
+| complex64 | X |  | X | X | X |
+| complex128 | X |  | X | X
+| long double (either 96 or 128 bits) |  |  | X | X |
+| long double complex (either 192 or 256 bits) |  |  | X |  |
+| Timedelta |  |  | X |  |
+| Datetime |  |  | X |  |
+| PythonObjects |  |  | X |  |
+| Raw Data |  |  | X |  |
+| qint8 (quantized int) | X |  |  | X |  |
+| qint16 (quantized int) |  |  |  | X |  |
+| qint32 (quantized int) |  |  |  | X |  |
+| qint32 (quantized int) | X |  |  | X |  |
+| quint8 (quantized unsigned int) | X |  |  | X |  |
+| quint16 (quantized unsigned int) |  |  |  | X |  |
+| quint32 (quantized unsigned int) |  |  |  | X |  |
+| quint64 (quantized unsigned int) |  |  |  | X |  |
+| quint2x4 | X |  |  |  |
+| quint4x2 | X |  |  |  |
+| Handle to mutable resource |  |  |  | X |  |
+|  |  |  |  |  |
+| **Other** |  |  |  |  |  |
+|  |  |  |  |  |
+| Supports Contiguous Memory | X | X | X | X |  |
+| Supports Non-Contiguous Memory |  |  | X | X |  |
+| Supports Sparse Tensors | X |  | X | X |  |
+
+
+ * Both Numpy and TensorFlow support Non-Contiguous memory, but its often less performant
+ * OnnxRuntime technically supports sparse tensors, but no kernels actually use them and they are not exposed in C#
+ * Other frameworks that do support sparse tensors each supports various versions of "sparse"
+ * Long double is either 96 or 128 bits based on underlying hardware


### PR DESCRIPTION
Adding in a folder under proposed for all the Tensor<T> information. This folder for now contains the type/memory comparisons for tensors in different frameworks. More documents will be added to this folder in the future.