### PR TITLE
Add examples of relative path to apphost-embed-install-location.md

### DIFF
--- a/proposed/apphost-embed-install-location.md
+++ b/proposed/apphost-embed-install-location.md
@@ -104,9 +104,12 @@ explicitly set to a value that does not include `AppRelative`, then setting
 `AppHostRelativeDotNet` is meaningless - the SDK will not write the relative
 path into the `apphost` and the `apphost` will not check for a relative path.
 
-The path must not be rooted and will be considered relative to the app location
-(the location of the `apphost` itself) at run time. For example, when running
-`C:\dir\app.exe` or `/home/dir/app` with `AppHostRelativeDotNet` set to:
+The path must not be rooted and will be written into the `apphost` unmodified.
+At run time, the path will be considered relative to the app location - that is,
+it is appended to the location of the `apphost` itself. The app relies on file
+system APIs of the underlying OS to determine if the path is valid and exists.
+
+When running `C:\dir\app.exe` or `/home/dir/app` with `AppHostRelativeDotNet` set to:
   - `my_dotnet`: the app will look at `C:\dir\my_dotnet` or `/home/dir/my_dotnet`
   - `./my_dotnet`: the app will look at `C:\dir\my_dotnet` or `/home/dir/my_dotnet`
   - `../my_dotnet` the app will look at `C:\my_dotnet` or `/home/my_dotnet`


### PR DESCRIPTION
Examples of relative path and corresponding behaviour per: https://github.com/dotnet/sdk/pull/42455#issuecomment-2261370773

cc @agocke @richlander @vitek-karas @dotnet/appmodel 