### PR TITLE
make the indexer tool run on the default ubuntu instance

### DIFF
--- a/tools/update-index/update-index.csproj
+++ b/tools/update-index/update-index.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>Enable</Nullable>
   </PropertyGroup>
 


### PR DESCRIPTION
Since ubuntu has floated to .NET 8 and the tool doesn't have roll-forward configured pipelines are failing.

Example failing job run:
https://github.com/dotnet/designs/actions/runs/13055636223/job/36425868529
![image](https://github.com/user-attachments/assets/8c6a1b9a-0ab4-4907-9970-8c5f0f6de50f)
