### PR TITLE
Add spec on cve.json schema

### DIFF
--- a/accepted/2025/cve-schema/cve.json
+++ b/accepted/2025/cve-schema/cve.json
@@ -1,0 +1,210 @@
+{
+  "date": "2024-07-09",
+  "cves": [
+    {
+      "id": "CVE-2024-30105",
+      "title": ".NET Denial of Service Vulnerability",
+      "severity": "Critical",
+      "cvss": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H/E:U/RL:O/RC:C",
+      "description": [
+        "A vulnerability exists in .NET when calling the JsonSerializer.DeserializeAsyncEnumerable method against an untrusted input using System.Text.Json may result in Denial of Service."
+      ],
+      "brand": ".NET",
+      "references": [
+        "https://github.com/dotnet/announcements/issues/315"
+      ]
+    },
+    {
+      "id": "CVE-2024-35264",
+      "title": ".NET Remote Code Execution Vulnerability",
+      "severity": "Critical",
+      "cvss": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H/E:U/RL:O/RC:C",
+      "description": [
+        "A Vulnerability exists in ASP.NET Core 8 where Data Corruption in Kestrel HTTP/3 can result in remote code execution.",
+        "Note: HTTP/3 is experimental in .NET 6.0. If you are on .NET 6.0 and using HTTP/3, please upgrade to .NET 8.0.7"
+      ],
+      "brand": "ASP.NET Core",
+      "references": [
+        "https://github.com/dotnet/announcements/issues/314"
+      ]
+    },
+    {
+      "id": "CVE-2024-38081",
+      "title": ".NET Denial of Service Vulnerability",
+      "severity": "Critical",
+      "cvss": "CVSS:3.1/AV:L/AC:L/PR:L/UI:R/S:U/C:H/I:H/A:H/E:U/RL:O/RC:C",
+      "description": [
+        "A vulnerability exists in Visual Studio installer on Windowswhere an unprivileged user is allowed to manipulate the Visual Studio installation resulting in elevation of privilege."
+      ],
+      "brand": ".NET",
+      "platforms": [
+        "Windows"
+      ],
+      "references": [
+        "https://github.com/dotnet/announcements/issues/313"
+      ]
+    },
+    {
+      "id": "CVE-2024-38095",
+      "title": ".NET Denial of Service Vulnerability",
+      "severity": "Critical",
+      "cvss": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L/E:U/RL:O/RC:C",
+      "description": [
+        "A vulnerability exists when System.Formats.Asn1 in .NET parses an X.509 certificate or collection of certificates, a malicious certificate can result in excessive CPU consumption on all platforms result in Denial of Service."
+      ],
+      "brand": ".NET",
+      "references": [
+        "https://github.com/dotnet/announcements/issues/312"
+      ]
+    }
+  ],
+  "core": [
+    {
+      "cve-id": "CVE-2024-38081",
+      "name": "Microsoft.NETCore.App.Runtime",
+      "min-vulnerable": "6.0.0",
+      "max-vulnerable": "6.0.31",
+      "fixed": "6.0.32",
+      "release": "6.0",
+      "commits": [
+        "0a0dd0e27560e692e11ee286ed9f45471b2131fa"
+      ]
+    },
+    {
+      "cve-id": "CVE-2024-38095",
+      "name": "Microsoft.NETCore.App.Runtime",
+      "min-vulnerable": "6.0.0",
+      "max-vulnerable": "6.0.31",
+      "fixed": "6.0.32",
+      "release": "6.0",
+      "commits": [
+        "979135d5ca4efaf6436ee13539cc3f1e039d570a"
+      ]
+    },
+    {
+      "cve-id": "CVE-2024-30105",
+      "name": "Microsoft.NETCore.App.Runtime",
+      "min-vulnerable": "8.0.0",
+      "max-vulnerable": "8.0.6",
+      "fixed": "8.0.7",
+      "release": "8.0",
+      "commits": [
+        "fa5b0d8f4a8b424732cc992158aa92842f8a2846"
+      ]
+    },
+    {
+      "cve-id": "CVE-2024-35264",
+      "name": "Microsoft.AspNetCore.App.Runtime",
+      "min-vulnerable": "8.0.0",
+      "max-vulnerable": "8.0.6",
+      "fixed": "8.0.7",
+      "release": "8.0",
+      "commits": [
+        "c5721fb7a65ddc13d1b445c2c08c27b72ab57cdc"
+      ]
+    },
+    {
+      "cve-id": "CVE-2024-38095",
+      "name": "Microsoft.NETCore.App.Runtime",
+      "min-vulnerable": "8.0.0",
+      "max-vulnerable": "8.0.6",
+      "fixed": "8.0.7",
+      "release": "8.0",
+      "commits": [
+        "4a8d5a007971d19f389ca17f7b8eb4f9bb199991"
+      ]
+    }
+  ],
+  "extensions": [
+    {
+      "cve-id": "CVE-2024-38081",
+      "name": "Microsoft.IO.Redist",
+      "min-vulnerable": "4.6.0-preview.18571.3",
+      "max-vulnerable": "6.0.0",
+      "fixed": "6.0.1",
+      "commits": [
+        "0a0dd0e27560e692e11ee286ed9f45471b2131fa"
+      ]
+    },
+    {
+      "cve-id": "CVE-2024-38095",
+      "name": "System.Formats.Asn1",
+      "min-vulnerable": "5.0.0-preview.7.20364.11",
+      "max-vulnerable": "6.0.0",
+      "fixed": "6.0.1",
+      "release": "6.0",
+      "commits": [
+        "979135d5ca4efaf6436ee13539cc3f1e039d570a"
+      ]
+    },
+    {
+      "cve-id": "CVE-2024-38095",
+      "name": "System.Formats.Asn1",
+      "min-vulnerable": "7.0.0-preview.1.22076.8",
+      "max-vulnerable": "8.0.0",
+      "fixed": "8.0.1",
+      "release": "8.0",
+      "commits": [
+        "4a8d5a007971d19f389ca17f7b8eb4f9bb199991"
+      ]
+    },
+    {
+      "cve-id": "CVE-2024-30105",
+      "name": "System.Text.Json",
+      "min-vulnerable": "8.0.0",
+      "max-vulnerable": "8.0.3",
+      "fixed": "8.0.4",
+      "release": "8.0",
+      "commits": [
+        "fa5b0d8f4a8b424732cc992158aa92842f8a2846"
+      ]
+    }
+  ],
+  "commits": {
+    "fa5b0d8f4a8b424732cc992158aa92842f8a2846": {
+      "repo": "runtime",
+      "branch": "release/8.0",
+      "hash": "fa5b0d8f4a8b424732cc992158aa92842f8a2846",
+      "org": "dotnet",
+      "url": "https://github.com/dotnet/runtime/commit/fa5b0d8f4a8b424732cc992158aa92842f8a2846"
+    },
+    "c5721fb7a65ddc13d1b445c2c08c27b72ab57cdc": {
+      "repo": "aspnetcore",
+      "branch": "release/8.0",
+      "hash": "c5721fb7a65ddc13d1b445c2c08c27b72ab57cdc",
+      "org": "dotnet",
+      "url": "https://github.com/dotnet/aspnetcore/commit/c5721fb7a65ddc13d1b445c2c08c27b72ab57cdc"
+    },
+    "0a0dd0e27560e692e11ee286ed9f45471b2131fa": {
+      "repo": "runtime",
+      "branch": "release/6.0",
+      "hash": "0a0dd0e27560e692e11ee286ed9f45471b2131fa",
+      "org": "dotnet",
+      "url": "https://github.com/dotnet/runtime/commit/0a0dd0e27560e692e11ee286ed9f45471b2131fa"
+    },
+    "4a8d5a007971d19f389ca17f7b8eb4f9bb199991": {
+      "repo": "runtime",
+      "branch": "release/8.0",
+      "hash": "4a8d5a007971d19f389ca17f7b8eb4f9bb199991",
+      "org": "dotnet",
+      "url": "https://github.com/dotnet/runtime/commit/4a8d5a007971d19f389ca17f7b8eb4f9bb199991"
+    },
+    "979135d5ca4efaf6436ee13539cc3f1e039d570a": {
+      "repo": "runtime",
+      "branch": "release/6.0",
+      "hash": "979135d5ca4efaf6436ee13539cc3f1e039d570a",
+      "org": "dotnet",
+      "url": "https://github.com/dotnet/runtime/commit/979135d5ca4efaf6436ee13539cc3f1e039d570a"
+    }
+  },
+  "cve-commits": {
+      "CVE-2024-30105": ["fa5b0d8f4a8b424732cc992158aa92842f8a2846"],
+      "CVE-2024-35264": ["c5721fb7a65ddc13d1b445c2c08c27b72ab57cdc"],
+      "CVE-2024-38081": ["0a0dd0e27560e692e11ee286ed9f45471b2131fa"],
+      "CVE-2024-38095": ["979135d5ca4efaf6436ee13539cc3f1e039d570a", "4a8d5a007971d19f389ca17f7b8eb4f9bb199991"]
+    },
+  "release-cves": {
+    "6.0": ["CVE-2024-38081", "CVE-2024-38095"],
+    "8.0": ["CVE-2024-30105", "CVE-2024-35264", "CVE-2024-38095"]
+  }
+}

--- a/accepted/2025/cve-schema/spec.md
+++ b/accepted/2025/cve-schema/spec.md
@@ -1,0 +1,483 @@
+# Publishing CVE information as structured data
+
+We publish vulnerability fixes and matching CVE documentation nearly ever month. These are primarily [documented on GitHub in HTML](https://github.com/dotnet/announcements/issues?q=is%3Aissue%20state%3Aopen%20label%3ASecurity) for people to read. It is well understood that HTML is a presentation format and not appropriate for structured processing. We intend to offer CVE information in structured JSON format (and likely markdown, too).
+
+This schema has been designed around a "core + extensions" model that reflects how many modern software platforms are structured - with core product components and an ecosystem of extensions. This pattern is prevalent across the industry (editors with extensions, runtimes with packages, apps with plugins), making this schema broadly applicable beyond its initial .NET use case. The design intentionally avoids product-specific terminology to support reuse by other offerings with similar security disclosure needs.
+
+We've taken a significant deparature with this schema design, battle-testing it with `jq` and some other tools as part of the development process. If the `jq` queries look bad, the schema is bad. We've also noticed in this new age that `jq` query ease is a proxy for LLM consumption ease. Great `jq` use will likely lead to good or better LLM consumption while bad `jq` queryability will likely lead to bad or worse LLM consumption. We intend to design all schema this way going forward.
+
+This new CVE format will be part of a larger queryable information graph that we'll document soon. For now, we'll focus on the CVE format.
+
+## Quick pitch
+
+Common queries answered by this schema:
+
+- "Which CVEs were reports this month?" → `.cves[].id`
+- "Which CVEs affect .NET 8.0?" → `release-cves["8.0"]`
+- "Which commits fix CVE-2024-38095?" → `cve-commits["CVE-2024-38095"]`
+- "Which extensions need updates?" → Browse `extensions[]` array
+- "What's the fix for System.Text.Json?" → Filter `extensions[]` by name
+
+## Key Design Decisions
+
+### 1. Arrays vs Dictionaries
+
+We use different data structures based on access patterns:
+
+- **Arrays for data (discovery)**: `cves[]`, `core[]`, and `extensions[]` contain the actual CVE and affected component data as arrays because users discover this information rather than knowing it a priori. The naming directly reflects the "core + extensions" model
+- **Dictionaries for indices (lookup)**: `commits{}`, `cve-commits{}`, and `release-cves{}` provide fast lookups for known keys
+
+This clear separation - arrays for what happened, dictionaries for finding things - creates a consistent mental model and emphasizes the role of indices as the primary lookup mechanism.
+
+We started with `product` and `packages` since that's the "core + extensions" model for .NET. That didn't feel like a strong pairing, outside of great aliteration, so we fell back `core` and `extensions`.
+
+### 2. Normalized Commit Data
+
+Commit details are stored once in a top-level `commits{}` dictionary, with other sections referencing commits by hash.
+
+Benefits:
+
+- Eliminates data duplication
+- Ensures consistency
+- Reduces file size
+- Maintains a single source of truth
+
+### 3. Join Indices
+
+We provide two "join as a service" indices to simplify common queries:
+
+#### `cve-commits`
+
+Maps CVE IDs to commit hashes:
+
+```json
+"cve-commits": {
+  "CVE-2024-38095": ["979135d5...", "4a8d5a0..."]
+}
+```
+
+Enables simple lookup: "Which commits fix this CVE?"
+
+#### `release-cves`
+
+Maps release families to affected CVEs:
+
+```json
+"release-cves": {
+  "8.0": ["CVE-2024-30105", "CVE-2024-35264", "CVE-2024-38095"]
+}
+```
+
+Answers: "What CVEs affect .NET 8.0?" (including core and extensions with `release: "8.0"`)
+
+**Note on terminology**: We use `release` to refer to major.minor version families (e.g., "8.0") that group all patch versions (8.0.0, 8.0.1, 8.0.7, etc.). This aligns with existing .NET release schemas and makes the format reusable by other versioned products. `release` is the same as `channel-version` used in other schemas.
+
+The indexes are a design tradeoff. The intent of the schema is to provide a fully normalized design (in a relational database sense) and also enable ergonomic `jq` queries. Those were found to be at odds. The calculated indexes break the normalization principle by introducing redundancy, but they transform complex multi-stage joins into simple lookups. Without them, common queries would require nested loops and variable juggling that make both human and LLM consumption difficult. We chose pragmatism over purity - the indices are a small storage compromise (just arrays of IDs) that provide enormous value in query simplicity. They serve as pre-computed views that make the schema actually usable. 
+
+### 4. Consistent Structure
+
+All data arrays (`cves[]`, `core[]`, `extensions[]`) share consistent patterns, with the core/extensions split directly mapping to the "core + extensions" model:
+
+- Each entry is self-contained with all necessary fields
+- `name`: Component/extension name for identification
+- `commits`: Array of commit hashes referencing the commits dictionary
+- Standard version range fields (`min-vulnerable`, `max-vulnerable`, `fixed`)
+
+Notes:
+
+- The `release` property is optional for extensions that aren't tied to a specific .NET release family (e.g., Microsoft.IO.Redist).
+- The `commits` property is optional, but encouraged.
+
+### 5. Query Optimization
+
+The schema prioritizes common query patterns:
+
+```bash
+# Simple CVE lookup
+jq -r '.cves[] | select(.severity == "Critical")'
+
+# Direct version access
+jq -r '.core[] | select(.release == "8.0")'
+
+# Clean commit lookups
+jq -r '. as $root | .["cve-commits"]["CVE-2024-38095"][] | $root.commits[.].url'
+```
+
+## Schema example
+
+```json
+{
+  "date": "2024-07-09",
+  "cves": [
+    {
+      "id": "CVE-2024-30105",
+      "title": ".NET Denial of Service Vulnerability",
+      "severity": "Critical",
+      "cvss": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H/E:U/RL:O/RC:C",
+      "description": [
+        "A vulnerability exists in .NET when calling the JsonSerializer.DeserializeAsyncEnumerable method against an untrusted input using System.Text.Json may result in Denial of Service."
+      ],
+      "brand": ".NET",
+      "references": [
+        "https://github.com/dotnet/announcements/issues/315"
+      ]
+    },
+    {
+      "id": "CVE-2024-35264",
+      "title": ".NET Remote Code Execution Vulnerability",
+      "severity": "Critical",
+      "cvss": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H/E:U/RL:O/RC:C",
+      "description": [
+        "A Vulnerability exists in ASP.NET Core 8 where Data Corruption in Kestrel HTTP/3 can result in remote code execution.",
+        "Note: HTTP/3 is experimental in .NET 6.0. If you are on .NET 6.0 and using HTTP/3, please upgrade to .NET 8.0.7"
+      ],
+      "brand": "ASP.NET Core",
+      "references": [
+        "https://github.com/dotnet/announcements/issues/314"
+      ]
+    },
+    {
+      "id": "CVE-2024-38081",
+      "title": ".NET Denial of Service Vulnerability",
+      "severity": "Critical",
+      "cvss": "CVSS:3.1/AV:L/AC:L/PR:L/UI:R/S:U/C:H/I:H/A:H/E:U/RL:O/RC:C",
+      "description": [
+        "A vulnerability exists in Visual Studio installer on Windowswhere an unprivileged user is allowed to manipulate the Visual Studio installation resulting in elevation of privilege."
+      ],
+      "brand": ".NET",
+      "platforms": [
+        "Windows"
+      ],
+      "references": [
+        "https://github.com/dotnet/announcements/issues/313"
+      ]
+    },
+    {
+      "id": "CVE-2024-38095",
+      "title": ".NET Denial of Service Vulnerability",
+      "severity": "Critical",
+      "cvss": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L/E:U/RL:O/RC:C",
+      "description": [
+        "A vulnerability exists when System.Formats.Asn1 in .NET parses an X.509 certificate or collection of certificates, a malicious certificate can result in excessive CPU consumption on all platforms result in Denial of Service."
+      ],
+      "brand": ".NET",
+      "references": [
+        "https://github.com/dotnet/announcements/issues/312"
+      ]
+    }
+  ],
+  "core": [
+    {
+      "cve-id": "CVE-2024-38081",
+      "name": "Microsoft.NETCore.App.Runtime",
+      "min-vulnerable": "6.0.0",
+      "max-vulnerable": "6.0.31",
+      "fixed": "6.0.32",
+      "release": "6.0",
+      "commits": [
+        "0a0dd0e27560e692e11ee286ed9f45471b2131fa"
+      ]
+    },
+    {
+      "cve-id": "CVE-2024-38095",
+      "name": "Microsoft.NETCore.App.Runtime",
+      "min-vulnerable": "6.0.0",
+      "max-vulnerable": "6.0.31",
+      "fixed": "6.0.32",
+      "release": "6.0",
+      "commits": [
+        "979135d5ca4efaf6436ee13539cc3f1e039d570a"
+      ]
+    },
+    {
+      "cve-id": "CVE-2024-30105",
+      "name": "Microsoft.NETCore.App.Runtime",
+      "min-vulnerable": "8.0.0",
+      "max-vulnerable": "8.0.6",
+      "fixed": "8.0.7",
+      "release": "8.0",
+      "commits": [
+        "fa5b0d8f4a8b424732cc992158aa92842f8a2846"
+      ]
+    },
+    {
+      "cve-id": "CVE-2024-35264",
+      "name": "Microsoft.AspNetCore.App.Runtime",
+      "min-vulnerable": "8.0.0",
+      "max-vulnerable": "8.0.6",
+      "fixed": "8.0.7",
+      "release": "8.0",
+      "commits": [
+        "c5721fb7a65ddc13d1b445c2c08c27b72ab57cdc"
+      ]
+    },
+    {
+      "cve-id": "CVE-2024-38095",
+      "name": "Microsoft.NETCore.App.Runtime",
+      "min-vulnerable": "8.0.0",
+      "max-vulnerable": "8.0.6",
+      "fixed": "8.0.7",
+      "release": "8.0",
+      "commits": [
+        "4a8d5a007971d19f389ca17f7b8eb4f9bb199991"
+      ]
+    }
+  ],
+  "extensions": [
+    {
+      "cve-id": "CVE-2024-38081",
+      "name": "Microsoft.IO.Redist",
+      "min-vulnerable": "4.6.0-preview.18571.3",
+      "max-vulnerable": "6.0.0",
+      "fixed": "6.0.1",
+      "commits": [
+        "0a0dd0e27560e692e11ee286ed9f45471b2131fa"
+      ]
+    },
+    {
+      "cve-id": "CVE-2024-38095",
+      "name": "System.Formats.Asn1",
+      "min-vulnerable": "5.0.0-preview.7.20364.11",
+      "max-vulnerable": "6.0.0",
+      "fixed": "6.0.1",
+      "release": "6.0",
+      "commits": [
+        "979135d5ca4efaf6436ee13539cc3f1e039d570a"
+      ]
+    },
+    {
+      "cve-id": "CVE-2024-38095",
+      "name": "System.Formats.Asn1",
+      "min-vulnerable": "7.0.0-preview.1.22076.8",
+      "max-vulnerable": "8.0.0",
+      "fixed": "8.0.1",
+      "release": "8.0",
+      "commits": [
+        "4a8d5a007971d19f389ca17f7b8eb4f9bb199991"
+      ]
+    },
+    {
+      "cve-id": "CVE-2024-30105",
+      "name": "System.Text.Json",
+      "min-vulnerable": "8.0.0",
+      "max-vulnerable": "8.0.3",
+      "fixed": "8.0.4",
+      "release": "8.0",
+      "commits": [
+        "fa5b0d8f4a8b424732cc992158aa92842f8a2846"
+      ]
+    }
+  ],
+  "commits": {
+    "fa5b0d8f4a8b424732cc992158aa92842f8a2846": {
+      "repo": "runtime",
+      "branch": "release/8.0",
+      "hash": "fa5b0d8f4a8b424732cc992158aa92842f8a2846",
+      "org": "dotnet",
+      "url": "https://github.com/dotnet/runtime/commit/fa5b0d8f4a8b424732cc992158aa92842f8a2846"
+    },
+    "c5721fb7a65ddc13d1b445c2c08c27b72ab57cdc": {
+      "repo": "aspnetcore",
+      "branch": "release/8.0",
+      "hash": "c5721fb7a65ddc13d1b445c2c08c27b72ab57cdc",
+      "org": "dotnet",
+      "url": "https://github.com/dotnet/aspnetcore/commit/c5721fb7a65ddc13d1b445c2c08c27b72ab57cdc"
+    },
+    "0a0dd0e27560e692e11ee286ed9f45471b2131fa": {
+      "repo": "runtime",
+      "branch": "release/6.0",
+      "hash": "0a0dd0e27560e692e11ee286ed9f45471b2131fa",
+      "org": "dotnet",
+      "url": "https://github.com/dotnet/runtime/commit/0a0dd0e27560e692e11ee286ed9f45471b2131fa"
+    },
+    "4a8d5a007971d19f389ca17f7b8eb4f9bb199991": {
+      "repo": "runtime",
+      "branch": "release/8.0",
+      "hash": "4a8d5a007971d19f389ca17f7b8eb4f9bb199991",
+      "org": "dotnet",
+      "url": "https://github.com/dotnet/runtime/commit/4a8d5a007971d19f389ca17f7b8eb4f9bb199991"
+    },
+    "979135d5ca4efaf6436ee13539cc3f1e039d570a": {
+      "repo": "runtime",
+      "branch": "release/6.0",
+      "hash": "979135d5ca4efaf6436ee13539cc3f1e039d570a",
+      "org": "dotnet",
+      "url": "https://github.com/dotnet/runtime/commit/979135d5ca4efaf6436ee13539cc3f1e039d570a"
+    }
+  },
+  "cve-commits": {
+      "CVE-2024-30105": ["fa5b0d8f4a8b424732cc992158aa92842f8a2846"],
+      "CVE-2024-35264": ["c5721fb7a65ddc13d1b445c2c08c27b72ab57cdc"],
+      "CVE-2024-38081": ["0a0dd0e27560e692e11ee286ed9f45471b2131fa"],
+      "CVE-2024-38095": ["979135d5ca4efaf6436ee13539cc3f1e039d570a", "4a8d5a007971d19f389ca17f7b8eb4f9bb199991"]
+    },
+  "release-cves": {
+    "6.0": ["CVE-2024-38081", "CVE-2024-38095"],
+    "8.0": ["CVE-2024-30105", "CVE-2024-35264", "CVE-2024-38095"]
+  }
+}
+```
+
+## Query examples
+
+The `jq` tool is a great way to concretely test the efficacy of a schema for query ability. The queries tell that story.
+
+### Discovery queries (browsing CVEs)
+
+#### Get all CVE IDs:
+
+```bash
+$ jq -r '.cves[].id' cve.json 
+CVE-2024-30105
+CVE-2024-35264
+CVE-2024-38081
+CVE-2024-38095
+```
+
+#### Get CVEs by severity
+
+```bash
+$ jq -r '.cves[] | select(.severity == "Critical") | .id' cve.json
+CVE-2024-30105
+CVE-2024-35264
+CVE-2024-38081
+CVE-2024-38095
+```
+
+#### Get CVE titles and IDs
+
+```bash
+$ jq -r '.cves[] | "\(.id): \(.title)"' cve.json
+CVE-2024-30105: .NET Denial of Service Vulnerability
+CVE-2024-35264: .NET Remote Code Execution Vulnerability
+CVE-2024-38081: .NET Denial of Service Vulnerability
+CVE-2024-38095: .NET Denial of Service Vulnerability
+```
+
+#### Get CVEs affecting specific brands
+
+```bash
+$ jq -r '.cves[] | select(.brand == "ASP.NET Core") | .id' cve.json
+CVE-2024-35264
+```
+
+### Version queries (what affects my version)
+
+#### Get fixed CVEs for a specific .NET version
+
+```bash
+$ jq -r '.["release-cves"]["8.0"][]' cve.json
+CVE-2024-30105
+CVE-2024-35264
+CVE-2024-38095
+```
+
+Note: We can project both core and extension (with `release` set) CVEs into this node.
+
+#### Get versions affected by a specific CVE
+
+```bash
+ $ jq -r '.["versions-cves"] | to_entries[] | select(.value[] == "CVE-2024-38095") | .key' cve.json
+  6.0
+  8.0
+```
+
+#### Count CVEs per version:
+
+```bash
+$ jq -r '.["versions-cves"] | to_entries[] | "\(.key): \(.value | length) CVEs"' cve.json
+  6.0: 2 CVEs
+  8.0: 3 CVEs
+```
+
+#### Get CVEs and commits for a given .NET version
+
+Using the indices (preferred):
+```bash
+$ jq -r '. as $root | .["release-cves"]["8.0"][] as $cve | $root["cve-commits"][$cve][] | "\($cve): \($root.commits[.].url)"' cve.json
+CVE-2024-30105: https://github.com/dotnet/runtime/commit/fa5b0d8f4a8b424732cc992158aa92842f8a2846
+CVE-2024-35264: https://github.com/dotnet/aspnetcore/commit/c5721fb7a65ddc13d1b445c2c08c27b72ab57cdc
+CVE-2024-38095: https://github.com/dotnet/runtime/commit/979135d5ca4efaf6436ee13539cc3f1e039d570a
+CVE-2024-38095: https://github.com/dotnet/runtime/commit/4a8d5a007971d19f389ca17f7b8eb4f9bb199991
+```
+
+Or filtering the product array:
+```bash
+$ jq -r '. as $root | .core[] | select(.release == "8.0") | .["cve-id"] as $cve | .commits[] | "\($cve): \($root.commits[.].url)"' cve.json
+```
+
+Just the commits:
+
+```bash
+$ jq -r '. as $root | .core[] | select(.release == "8.0") | .commits[] | $root.commits[.].url' cve.json
+https://github.com/dotnet/runtime/commit/fa5b0d8f4a8b424732cc992158aa92842f8a2846
+https://github.com/dotnet/aspnetcore/commit/c5721fb7a65ddc13d1b445c2c08c27b72ab57cdc
+https://github.com/dotnet/runtime/commit/4a8d5a007971d19f389ca17f7b8eb4f9bb199991
+```
+
+### Extension queries (what extensions need updates)
+
+#### Get all affected extensions
+
+```bash
+$ jq -r '.extensions[] | .name' cve.json | sort -u
+Microsoft.IO.Redist
+System.Formats.Asn1
+System.Text.Json
+```
+
+#### Get fixed versions for extensions
+
+```bash
+$ jq -r '.extensions[] | "\(.["cve-id"]): fixed in \(.fixed) (extension: \(.name))"' cve.json
+CVE-2024-38081: fixed in 6.0.1 (extension: Microsoft.IO.Redist)
+CVE-2024-38095: fixed in 6.0.1 (extension: System.Formats.Asn1)
+CVE-2024-38095: fixed in 8.0.1 (extension: System.Formats.Asn1)
+CVE-2024-30105: fixed in 8.0.4 (extension: System.Text.Json)
+```
+
+#### Get fixed versions for a specific extension
+
+```bash
+$ jq -r '.extensions[] | select(.name == "System.Text.Json") | "\(.["cve-id"]): fixed in \(.fixed)"' cve.json
+CVE-2024-30105: fixed in 8.0.4
+```
+
+#### Check if an extension is affected
+
+```bash
+$ jq -r '.extensions[] | select(.name == "System.Text.Rich") | "\(.["cve-id"]): fixed in \(.fixed)"' cve.json
+$
+```
+(No output means not affected)
+
+#### Extensions with no `release`
+
+```bash
+$ jq -r '.extensions[] | select(.release == null) | .name' cve.json | sort -u
+Microsoft.IO.Redist
+```
+
+### Investigation queries (diving into specific CVEs)
+
+#### Get Commits for a given CVE
+
+```bash
+$ jq -r '. as $root | .["cve-commits"]["CVE-2024-38095"][] | $root.commits[.].url' cve.json
+https://github.com/dotnet/runtime/commit/979135d5ca4efaf6436ee13539cc3f1e039d570a
+https://github.com/dotnet/runtime/commit/4a8d5a007971d19f389ca17f7b8eb4f9bb199991
+```
+
+#### Get all extensions affected by Critical CVEs
+
+```bash
+$ jq -r '. as $root | 
+  [$root.cves[] | select(.severity == "Critical") | .id] as $critical_cves |
+  $root.extensions[] | 
+  select(.["cve-id"] as $cve | $critical_cves | contains([$cve])) | 
+  "\(.name): \(.["cve-id"])"' cve.json
+Microsoft.IO.Redist: CVE-2024-38081
+System.Formats.Asn1: CVE-2024-38095
+System.Formats.Asn1: CVE-2024-38095
+System.Text.Json: CVE-2024-30105
+```


### PR DESCRIPTION
We publish vulnerability fixes and matching CVE documentation nearly ever month. These are primarily [documented on GitHub in HTML](https://github.com/dotnet/announcements/issues?q=is%3Aissue%20state%3Aopen%20label%3ASecurity) for people to read. It is well understood that HTML is a presentation format and not appropriate for structured processing. We intend to offer CVE information in structured JSON format (and likely markdown, too).

This schema has been designed around a "core + extensions" model that reflects how many modern software platforms are structured - with core product components and an ecosystem of extensions. This pattern is prevalent across the industry (editors with extensions, runtimes with packages, apps with plugins), making this schema broadly applicable beyond its initial .NET use case. The design intentionally avoids product-specific terminology to support reuse by other offerings with similar security disclosure needs.

I also have a C# object model for the schema. I'll share that shortly. It's currently broken because I made a bunch of schema changes as a result of insight from writing the spec.