### PR TITLE
Add reference to .NET Memory Model

### DIFF
--- a/accepted/2025/memory-safety/caller-unsafe.md
+++ b/accepted/2025/memory-safety/caller-unsafe.md
@@ -16,6 +16,7 @@ The overall goal is to ensure .NET code is "valid" with respect to certain prope
 
 * Memory safety
 * No access to uninitialized memory
+* The [.NET Memory Model](https://github.com/dotnet/runtime/blob/main/docs/design/specs/Memory-model.md)
 
 The complete definition of these properties is in [Global invariants](#global-invariants).
 

--- a/accepted/2025/memory-safety/caller-unsafe.md
+++ b/accepted/2025/memory-safety/caller-unsafe.md
@@ -139,7 +139,7 @@ These properties are guaranteed by "safe" code through a combination of compiler
 
 The .NET memory model contains guarantees which must not be violated by unsafe code:
 
-* Managed references must always point to aligned data
+* Managed references must always be aligned
 
 ### Non-goals
 

--- a/accepted/2025/memory-safety/caller-unsafe.md
+++ b/accepted/2025/memory-safety/caller-unsafe.md
@@ -115,10 +115,11 @@ public sealed class RequiresUnsafeAttribute : System.Attribute
 
 ### Global invariants
 
-Two properties which should always hold in .NET programs are:
+Three properties which should always hold in .NET programs are:
 
 * Memory safety
 * No access to uninitialized memory
+* Alignment with the .NET Memory Model
 
 The "safe" subset of C# must guarantee these properties by construction. The unsafe subset cannot be guaranteed entirely by the system -- it needs external validation by the user or other tooling.
 
@@ -133,6 +134,12 @@ These properties are particularly important for security purposes. Any methods t
 These properties are guaranteed by "safe" code through a combination of compiler and .NET runtime enforcement. For `unsafe` code, these properties must be guaranteed by the programmer.
 
 `unsafe` members are used to identify the places that cannot be automatically checked by the compiler and runtime for validity. Inside unsafe blocks, the programmer is responsible for ensuring that all requirements of the unsafe code are met, and that all code outside the block will have validity properly enforced by the system.
+
+#### .NET Memory Model Alignment
+
+The .NET memory model contains guarantees which must not be violated by unsafe code:
+
+* Managed references must always point to aligned data
 
 ### Non-goals
 


### PR DESCRIPTION
All code should preserve the guarantees of the .NET memory model, therefore this should be in the list.